### PR TITLE
Fix warning of unknown variable

### DIFF
--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -29,6 +29,7 @@
 (require 'cl-lib)
 (require 'format-spec)
 (require 'faces)
+(require 'image-mode)
 
 ;; These functions are only used after a PdfView window was asserted,
 ;; which won't succeed, if pdf-view.el isn't loaded.


### PR DESCRIPTION
Hi vedang,

Thanks for maintaining pdf-tools package!

During native compilation I am greeted with these warnings:
Warning (comp): pdf-util.el:113:36: Warning: reference to free variable ‘image-mode-winprops-alist’ 
Warning (comp): pdf-util.el:114:39: Warning: assignment to free variable ‘image-mode-winprops-alist’ 

These can be fixed by adding a explicitly require for feature image-mode.