### PR TITLE
Support for HiDPI display on vanilla emacs

### DIFF
--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -945,12 +945,14 @@ See also `regexp-quote'."
 
 (defun pdf-util-frame-scale-factor ()
   "Return the frame scale factor depending on the image type used for display.
-When `pdf-view-use-scaling' is non-nil, return the
-backing-scale-factor of the frame if available. If a
-backing-scale-factor attribute isn't available, return 2 if the
+When `pdf-view-use-scaling' is non-nil, return the scale factor of the frame
+if available. If the scale factor isn't available, return 2 if the
 frame's PPI is larger than 180. Otherwise, return 1."
   (if pdf-view-use-scaling
-      (or (cdr (assq 'backing-scale-factor (frame-monitor-attributes)))
+      (or (and (fboundp 'frame-scale-factor)
+               (frame-scale-factor))
+          (and (fboundp 'frame-monitor-attributes)
+               (cdr (assq 'backing-scale-factor (frame-monitor-attributes))))
           (if (>= (pdf-util-frame-ppi) 180)
               2
             1))

--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -950,7 +950,7 @@ if available. If the scale factor isn't available, return 2 if the
 frame's PPI is larger than 180. Otherwise, return 1."
   (if pdf-view-use-scaling
       (or (and (fboundp 'frame-scale-factor)
-               (frame-scale-factor))
+               (truncate (frame-scale-factor)))
           (and (fboundp 'frame-monitor-attributes)
                (cdr (assq 'backing-scale-factor (frame-monitor-attributes))))
           (if (>= (pdf-util-frame-ppi) 180)

--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -945,14 +945,11 @@ See also `regexp-quote'."
 
 (defun pdf-util-frame-scale-factor ()
   "Return the frame scale factor depending on the image type used for display.
-When `pdf-view-use-scaling' is non-nil and imagemagick or
-image-io are used as the image type for display, return the
+When `pdf-view-use-scaling' is non-nil, return the
 backing-scale-factor of the frame if available. If a
 backing-scale-factor attribute isn't available, return 2 if the
 frame's PPI is larger than 180. Otherwise, return 1."
-  (if (and pdf-view-use-scaling
-           (memq (pdf-view-image-type) '(imagemagick image-io))
-           (fboundp 'frame-monitor-attributes))
+  (if pdf-view-use-scaling
       (or (cdr (assq 'backing-scale-factor (frame-monitor-attributes)))
           (if (>= (pdf-util-frame-ppi) 180)
               2

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -910,9 +910,7 @@ See also `pdf-view-use-imagemagick'."
 
 (defun pdf-view-use-scaling-p ()
   "Return t if scaling should be used."
-  (and (memq (pdf-view-image-type)
-             '(imagemagick image-io))
-       pdf-view-use-scaling))
+  pdf-view-use-scaling)
 
 (defmacro pdf-view-create-image (data &rest props)
   ;; TODO: add DATA and PROPS to docstring.

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -92,10 +92,7 @@ FIXME: Explain dis-/advantages of imagemagick and png."
 This variable affects both the reuse of higher-resolution images
 as lower-resolution ones by down-scaling the image.  As well as
 the rendering of higher-resolution for high-resolution displays,
-if available.
-
-It has no effect, unless either the imagemagick or image-io
-image-format is available."
+if available."
   :group 'pdf-view
   :type 'boolean)
 


### PR DESCRIPTION
This is related to the long-standing issue of displaying pdf contents in proper resolution on retina Macs using vanilla (not a fork) emacs:
politza/pdf-tools#51
hlissner/doom-emacs#4989

[This commit](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=4e1f92feb3a861f93b7a285715d03be930b41b91) of Emacs introduces a function `frame-scale-factor` which returns the scale factor of the backing store on NS framework in particular. So far pdf-tools has been using `backing-scale-factor` attribute of `(frame-monitor-attributes)`, which is not a standard emacs attribute, but a feature provided by [emacs-mac](https://bitbucket.org/mituharu/emacs-mac) port.

Also, for some reason the scaling wasn't applied if `png` was used as the image type. I've tested around and `png` with scaling works flawlessly. Rather contrary, `png` is the only image type which successfully scales for me, and using `imagemagick` does not work (even on regular image buffers). `image-io` is also something not present in GNU Emacs and provided solely by `emacs-mac`