### PR TITLE
Explicitly pass width through `pdf-view-create-image`

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -981,7 +981,8 @@ other annotations."
                 page (car size)
                 `("white" "steel blue" 0.35 ,@edges))
              :map (pdf-view-apply-hotspot-functions
-                   window page size))))
+                   window page size)
+             :width (car size))))
         (pdf-util-scroll-to-edges
          (pdf-util-scale-relative-to-pixel (car edges)))))))
 

--- a/lisp/pdf-isearch.el
+++ b/lisp/pdf-isearch.el
@@ -742,7 +742,7 @@ MATCH-BG LAZY-FG LAZY-BG\)."
                                  occur-hack-p)
                              (eq page (pdf-view-current-page)))
                     (pdf-view-display-image
-                     (pdf-view-create-image data))))))))
+                     (pdf-view-create-image data :width width))))))))
       (pdf-info-renderpage-text-regions
        page width t nil
        `(,fg1 ,bg1 ,@(pdf-util-scale-pixel-to-relative

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -1429,7 +1429,8 @@ This is more useful for commands like
               `(,(car colors) ,(cdr colors) 0.35 ,@region))
            (pdf-info-renderpage-text-regions
             page width nil nil
-            `(,(car colors) ,(cdr colors) ,@region)))))))
+            `(,(car colors) ,(cdr colors) ,@region)))
+       :width width))))
 
 (defun pdf-view-kill-ring-save ()
   "Copy the region to the `kill-ring'."


### PR DESCRIPTION
This is to avoid repeatedly scaling the displayed image width when applying highlighting (#19).

As it turns out, it wasn't only `isearch` and `occur` which were broken, but everything that includes highlighting: selection and jump to annotation (`C-c C-a l SPC`) as well.

The behavior was caused by passing the value of `(pdf-view-image-size)` into the highlight functions (`pdf-info-renderpage-text-regions` and `pdf-info-renderpage-highlight`) and using the result as it is, without readjusting the displayed image width (as it's done when displaying raw pages without any highlighted elements, see [this line](https://github.com/vedang/pdf-tools/blob/df2eea87aa84711024b48b2184b1c1ca1b2d0e7b/lisp/pdf-view.el#L935)).

This caused the image width to be multiplied with the `frame-scale-factor` in `pdf-info-renderpage` and the width of the returned raw image to be interpreted by `create-image` as the requested width of the image as seen in the buffer.

Fixed by passing the width explicitly in every call to `pdf-view-create-image`, except for [this one](https://github.com/vedang/pdf-tools/blob/df2eea87aa84711024b48b2184b1c1ca1b2d0e7b/lisp/pdf-annot.el#L1365), which seems to be responsible for latex fragment rendering.

I tested this on Emacs 28 on Mac and in emacs-mac and both seem to work ok. @salutis, could you test this on your machine as well?