### PR TITLE
define-minor-mode: Remove support for obsolete pos arguments

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -322,7 +322,7 @@ Setting this after the package was loaded has no effect."
   "Support for PDF Annotations.
 
 \\{pdf-annot-minor-mode-map}"
-  nil nil nil
+  :group 'pdf-annot
   (cond
    (pdf-annot-minor-mode
     (when pdf-annot-tweak-tooltips
@@ -1421,7 +1421,7 @@ annotation's contents and otherwise `text-mode'. "
 
 (define-minor-mode pdf-annot-edit-contents-minor-mode
   "Active when editing the contents of annotations."
-  nil nil nil
+  :group 'pdf-annot
   (when pdf-annot-edit-contents-minor-mode
     (message "%s"
              (substitute-command-keys
@@ -1772,7 +1772,8 @@ belong to the same page and A1 is displayed above/left of A2."
             (pdf-annot-getannot id pdf-annot-list-document-buffer)))))
 
 (define-minor-mode pdf-annot-list-follow-minor-mode
-  "" nil nil nil
+  ""
+  :group 'pdf-annot
   (unless (derived-mode-p 'pdf-annot-list-mode)
     (error "No in pdf-annot-list-mode."))
   (cond

--- a/lisp/pdf-cache.el
+++ b/lisp/pdf-cache.el
@@ -339,7 +339,7 @@ See also `pdf-info-renderpage-highlight' and
 
 (define-minor-mode pdf-cache-prefetch-minor-mode
   "Try to load images which will probably be needed in a while."
-  nil nil nil
+  :group 'pdf-cache
   (pdf-cache--prefetch-cancel)
   (cond
    (pdf-cache-prefetch-minor-mode

--- a/lisp/pdf-dev.el
+++ b/lisp/pdf-dev.el
@@ -54,7 +54,7 @@ Installs a `compilation-finish-functions' which will restart
 epdfinfo after a successful recompilation.
 
 Sets up `load-path' and reloads all PDF Tools lisp files."
-  nil nil nil
+  :group 'pdf-dev
   (let ((lisp-dir (expand-file-name "lisp" pdf-dev-root-directory)))
     (setq load-path (remove lisp-dir load-path))
     (cond

--- a/lisp/pdf-history.el
+++ b/lisp/pdf-history.el
@@ -52,7 +52,7 @@ following a link pushes the left-behind page on the stack, which
 may be navigated with the following keys.
 
 \\{pdf-history-minor-mode-map}"
-  nil nil nil
+  :group 'pdf-history
   (pdf-util-assert-pdf-buffer)
   (pdf-history-clear)
   (cond

--- a/lisp/pdf-isearch.el
+++ b/lisp/pdf-isearch.el
@@ -127,7 +127,9 @@ keymap is `isearch-mode-map'.")
 (put 'image-scroll-up 'isearch-scroll t)
 (put 'image-scroll-down 'isearch-scroll t)
 
-(define-minor-mode pdf-isearch-active-mode "" nil nil nil
+(define-minor-mode pdf-isearch-active-mode
+  ""
+  :group 'pdf-isearch
   (cond
    (pdf-isearch-active-mode
     (set (make-local-variable 'isearch-mode-map)
@@ -218,7 +220,6 @@ If this mode is enabled, isearching does not stop at every match,
 but rather moves to the next one not currently visible.  This
 behaviour is much faster than ordinary isearch, since far less
 different images have to be displayed."
-  nil nil nil
   :group 'pdf-isearch
   (when isearch-mode
     (pdf-isearch-redisplay)

--- a/lisp/pdf-links.el
+++ b/lisp/pdf-links.el
@@ -111,8 +111,6 @@ one of the displayed keys, or by using isearch limited to
 links via \\[pdf-links-isearch-link].
 
 \\{pdf-links-minor-mode-map}"
-
-  nil nil nil
   :group 'pdf-links
   (pdf-util-assert-pdf-buffer)
   (cond

--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -38,12 +38,12 @@
 ;;;###autoload
 (define-minor-mode pdf-misc-minor-mode
   "FIXME:  Not documented."
-  nil nil nil)
+  :group 'pdf-misc)
 
 ;;;###autoload
 (define-minor-mode pdf-misc-size-indication-minor-mode
   "Provide a working size indication in the mode-line."
-  nil nil nil
+  :group 'pdf-misc
   (pdf-util-assert-pdf-buffer)
   (cond
    (pdf-misc-size-indication-minor-mode
@@ -171,7 +171,7 @@
 ;;;###autoload
 (define-minor-mode pdf-misc-menu-bar-minor-mode
   "Display a PDF Tools menu in the menu-bar."
-  nil nil nil
+  :group 'pdf-misc
   (pdf-util-assert-pdf-buffer))
 
 (defvar pdf-misc-context-menu-minor-mode-map
@@ -184,7 +184,7 @@
   "Provide a right-click context menu in PDF buffers.
 
 \\{pdf-misc-context-menu-minor-mode-map}"
-  nil nil nil
+  :group 'pdf-misc
   (pdf-util-assert-pdf-buffer))
 
 (defun pdf-misc-popup-context-menu (event)

--- a/lisp/pdf-occur.el
+++ b/lisp/pdf-occur.el
@@ -353,8 +353,9 @@ Compatibility function for \\[next-error] invocations."
 
 This global minor mode enables (or disables)
 `pdf-occur-ibuffer-minor-mode' and `pdf-occur-dired-minor-mode'
-in all current and future ibuffer/dired buffer."  nil nil nil
-:global t
+in all current and future ibuffer/dired buffer."
+  :global t
+  :group 'pdf-occur
   (let ((arg (if pdf-occur-global-minor-mode 1 -1)))
     (dolist (buf (buffer-list))
       (with-current-buffer buf
@@ -385,8 +386,7 @@ This mode remaps `ibuffer-do-occur' to
 `pdf-occur-ibuffer-do-occur', which will start the PDF Tools
 version of `occur', if all marked buffer's are in `pdf-view-mode'
 and otherwise fallback to `ibuffer-do-occur'."
-
-  nil nil nil)
+  :group 'pdf-occur)
 
 (defun pdf-occur-ibuffer-do-occur (&optional regexp-p)
   "Uses `pdf-occur-search', if appropriate.
@@ -421,8 +421,7 @@ This mode remaps `dired-do-search' to
 `pdf-occur-dired-do-search', which will start the PDF Tools
 version of `occur', if all marked buffer's are in `pdf-view-mode'
 and otherwise fallback to `dired-do-search'."
-
-  nil nil nil)
+  :group 'pdf-occur)
 
 (defun pdf-occur-dired-do-search ()
   "Uses `pdf-occur-search', if appropriate.

--- a/lisp/pdf-outline.el
+++ b/lisp/pdf-outline.el
@@ -148,7 +148,7 @@ Additionally the same outline may be viewed in a designated
 buffer.
 
 \\{pdf-outline-minor-mode-map}"
-  nil nil nil
+  :group 'pdf-outline
   (pdf-util-assert-pdf-buffer)
   (cond
    (pdf-outline-minor-mode
@@ -193,7 +193,7 @@ rebound to their respective last character.
 
 (define-minor-mode pdf-outline-follow-mode
   "Display links as point moves."
-  nil nil nil
+  :group 'pdf-outline
   (setq pdf-outline-follow-mode-last-link nil)
   (cond
    (pdf-outline-follow-mode

--- a/lisp/pdf-sync.el
+++ b/lisp/pdf-sync.el
@@ -132,8 +132,7 @@ to `pdf-sync-forward-search' in `TeX-source-correlate-map'.  This
 function displays the PDF page corresponding to the current
 position in the TeX buffer.  This function only works together
 with AUCTeX."
-
-  nil nil nil
+  :group 'pdf-sync
   (pdf-util-assert-pdf-buffer))
 
 
@@ -539,7 +538,7 @@ word-level searching is desired."
 
 (define-minor-mode pdf-sync-backward-debug-minor-mode
   "Aid in debugging the backward search."
-  nil nil nil
+  :group 'pdf-sync
   (if (and (fboundp 'advice-add)
            (fboundp 'advice-remove))
       (let ((functions

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -866,7 +866,7 @@ again."
   "Automatically slice pages according to their bounding boxes.
 
 See also `pdf-view-set-slice-from-bounding-box'."
-  nil nil nil
+  :group 'pdf-view
   (pdf-util-assert-pdf-buffer)
   (cond
    (pdf-view-auto-slice-minor-mode
@@ -1141,7 +1141,7 @@ This will display a text cursor, when hovering over them."
   "Mode for PDF documents with dark background.
 
 This tells the various modes to use their face's dark colors."
-  nil nil nil
+  :group 'pdf-view
   (pdf-util-assert-pdf-buffer)
   ;; FIXME: This should really be run in a hook.
   (when (bound-and-true-p pdf-isearch-active-mode)
@@ -1152,7 +1152,8 @@ This tells the various modes to use their face's dark colors."
 
 (define-minor-mode pdf-view-printer-minor-mode
   "Display the PDF as it would be printed."
-  nil " Prn" nil
+  :group 'pdf-view
+  :lighter " Prn"
   (pdf-util-assert-pdf-buffer)
   (let ((enable (lambda ()
                   (pdf-info-setoptions :render/printed t))))
@@ -1172,8 +1173,8 @@ This tells the various modes to use their face's dark colors."
 
 The colors are determined by the variable
 `pdf-view-midnight-colors', which see. "
-
-  nil " Mid" nil
+  :group 'pdf-view
+  :lighter " Mid"
   (pdf-util-assert-pdf-buffer)
   ;; FIXME: Maybe these options should be passed stateless to pdf-info-renderpage ?
   (let ((enable (lambda ()
@@ -1217,8 +1218,8 @@ current theme's colors."
 
 The colors are determined by the `face-foreground' and
 `face-background' of the currently active theme."
-
-  nil " Thm" nil
+  :group 'pdf-view
+  :lighter " Thm"
   (pdf-util-assert-pdf-buffer)
   (cond
    (pdf-view-themed-minor-mode

--- a/lisp/pdf-virtual.el
+++ b/lisp/pdf-virtual.el
@@ -477,7 +477,6 @@ PAGE should be a page-number."
 ;;;###autoload
 (define-minor-mode pdf-virtual-global-minor-mode
   "Enable recognition and handling of VPDF files."
-  nil nil nil
   :global t
   :group 'pdf-tools
   (let ((elt `(,pdf-virtual-magic-mode-regexp . pdf-virtual-view-mode)))


### PR DESCRIPTION
This removes the positial arguemnt triplet from the define-minor-mode
calls, because they are obsolete since Emacs 21. See the following
paragraph in the help section of define-minor-mode:

For backward compatibility with the Emacs<21 calling convention, the
keywords of define-minor-mode can also be preceded by the obsolete
triplet INIT-VALUE LIGHTER KEYMAP.