### PR TITLE
Update Appveyor configs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,9 @@ version: 1.0.{build}
 
 environment:
   matrix:
-  - COMPILER: msys2
+  - FLAVOR: mingw64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    COMPILER: msys2
     PLATFORM: x64
     MSYS2_ARCH: x86_64
     MSYS2_DIR: msys64

--- a/ci/appveyor/install.bat
+++ b/ci/appveyor/install.bat
@@ -9,30 +9,13 @@ echo MSYS2 directory: %MSYS2_DIR%
 echo MSYS2 system: %MSYSTEM%
 echo Bits: %BIT%
 
-REM Create a writeable TMPDIR
-mkdir %APPVEYOR_BUILD_FOLDER%\tmp
-set TMPDIR=%APPVEYOR_BUILD_FOLDER%\tmp
-
 IF %COMPILER%==msys2 (
   @echo on
   SET "PATH=C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;C:\%MSYS2_DIR%\home\appveyor\.cask\bin;%PATH%"
 
-  bash -lc "pacman -S --needed --noconfirm git"
-
   REM dependencies
-  bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-zlib mingw-w64-x86_64-libpng mingw-w64-x86_64-poppler mingw-w64-x86_64-imagemagick openssl mingw-w64-x86_64-openssl mingw-w64-x86_64-python2"
-
-  REM Set up emacs
-  bash -lc "pacman -S --needed --noconfirm mingw-w64-x86_64-emacs"
+  bash -lc "pacman -S --needed --noconfirm git mingw-w64-x86_64-zlib mingw-w64-x86_64-libpng mingw-w64-x86_64-poppler mingw-w64-x86_64-imagemagick openssl mingw-w64-x86_64-openssl mingw-w64-x86_64-python2 mingw-w64-x86_64-emacs"
 
   REM Set up Cask
   bash -lc "git clone https://github.com/cask/cask ~/.cask"
-
-  REM Download ssleay32 and libeay32 dlls
-  bash -lc "pushd /c/projects/pdf-tools; curl -fsSL https://indy.fulgan.com/SSL/openssl-1.0.2u-x64_86-win64.zip -o ./tmp/openssl.zip"
-
-  REM Extract *eay32 dlls to TMP
-  7z x -o%TMPDIR%\ %TMPDIR%\openssl.zip
-  bash -lc "pushd /c/projects/pdf-tools; echo Indy Fulgan download complete; pwd; ls -la ./tmp/"
-
 )

--- a/ci/appveyor/pack.bat
+++ b/ci/appveyor/pack.bat
@@ -13,9 +13,9 @@ IF %COMPILER%==msys2 (
   REM Copy epdfinfo.exe and all dependencies
   bash -lc "pushd /c/projects/pdf-tools; ldd server/epdfinfo.exe | grep mingw | cut -d' ' -f 3 | xargs -I {} cp {} ./pack/; cp server/epdfinfo.exe ./pack/"
 
-  REM Copy dlls to pack
-  cp %TMPDIR%\ssleay32.dll %PACKDIR%\
-  cp %TMPDIR%\libeay32.dll %PACKDIR%\
+  REM Copy openssl dlls to pack
+  copy C:\%MSYS2_DIR%\%MSYSTEM%\bin\libcrypto*.dll %PACKDIR%\
+  copy C:\%MSYS2_DIR%\%MSYSTEM%\bin\libssl*.dll %PACKDIR%\
 
   REM Package epdfinfo.exe and all dependencies
   7z a epdfinfo.zip %PACKDIR%\*.*


### PR DESCRIPTION
- Use VS 2019 image
- Combine pacman install commands
- For some reason, OpenSSL dlls were not copied along with other dependencies. Update to copy
explicitly. Also remove previous workaround.