### PR TITLE
Sanitize buffer name for use as temp file prefix

### DIFF
--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -558,12 +558,7 @@ killed."
       (let ((temporary-file-directory
              pdf-util--base-directory))
         (setq pdf-util--dedicated-directory
-              (make-temp-file (convert-standard-filename
-			       (concat (if buffer-file-name
-					   (file-name-nondirectory
-					    buffer-file-name)
-					 (buffer-name))
-				       "-"))
+              (make-temp-file (convert-standard-filename (pdf-util-temp-prefix))
                               t))
         (add-hook 'kill-buffer-hook 'pdf-util-delete-dedicated-directory
                   nil t)))
@@ -577,13 +572,21 @@ killed."
   "Expand filename against current buffer's dedicated directory."
   (expand-file-name name (pdf-util-dedicated-directory)))
 
-(defun pdf-util-make-temp-file (prefix &optional dir-flag suffix)
+(defun pdf-util-temp-prefix ()
+  "Create a temp-file prefix for the current buffer"
+  (concat (if buffer-file-name
+              (file-name-nondirectory buffer-file-name)
+            (replace-regexp-in-string "[^[:alnum:]]+" "-" (buffer-name)))
+          "-"))
+
+(defun pdf-util-make-temp-file (&optional prefix dir-flag suffix)
   "Create a temporary file in current buffer's dedicated directory.
 
 See `make-temp-file' for the arguments."
-  (let ((temporary-file-directory
-         (pdf-util-dedicated-directory)))
-    (make-temp-file (convert-standard-filename prefix) dir-flag suffix)))
+  (let ((temporary-file-directory (pdf-util-dedicated-directory)))
+    (make-temp-file (convert-standard-filename
+                     (or prefix (pdf-util-temp-prefix)))
+                    dir-flag suffix)))
 
 
 ;; * ================================================================== *

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -319,12 +319,7 @@ PNG images in Emacs buffers."
                    (not (and buffer-file-name
                              (file-readable-p buffer-file-name)))))
              (pdf-tools-pdf-buffer-p))
-    (let ((tempfile (pdf-util-make-temp-file
-                     (concat (if buffer-file-name
-                                 (file-name-nondirectory
-                                  buffer-file-name)
-                               (buffer-name))
-                             "-"))))
+    (let ((tempfile (pdf-util-make-temp-file)))
       (write-region nil nil tempfile nil 'no-message)
       (setq-local pdf-view--buffer-file-name tempfile)))
   ;; Decryption needs to be done before any other function calls into


### PR DESCRIPTION
Currently, this package uses temporary files whose names are derived
from either the file name associated with the pdf-view buffer, or the
buffer name if it is not visiting a file.  If the buffer name contains
`/` characters, then it is not a valid file name. This patch cleans up
non-alphanumeric characters in the buffer name before using it as a
temp file prefix.

This is useful for buffers that were created directly from URLs, where
the buffer name is usually the full URL containing slashes. For
example, the command `crux-view-url` from the `crux` package downloads
the contents of a URL into a new buffer, and selects the appropriate
mode for it. Enabling `pdf-view-mode` fails on such buffers with the
current version of the package.