### PR TITLE
adapt emacs' easy-menu change

### DIFF
--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -192,8 +192,10 @@
   (interactive "@e")
   (popup-menu
    (cons 'keymap
-         (cddr (lookup-key pdf-misc-menu-bar-minor-mode-map
-                           [menu-bar PDF\ Tools])))))
+         (cddr (or (lookup-key pdf-misc-menu-bar-minor-mode-map
+                               [menu-bar PDF\ Tools])
+                   (lookup-key pdf-misc-menu-bar-minor-mode-map
+                               [menu-bar pdf\ tools]))))))
 
 (defun pdf-misc-display-metadata ()
   "Display all available metadata in a separate buffer."


### PR DESCRIPTION
Emacs had made some change to the easy-menu system, that is, easy-menu-define lowers the menu-bar key automatically.

Ref: https://lists.gnu.org/archive/html/bug-gnu-emacs/2021-09/msg02038.html

Signed-off-by: Shuguang Sun <shuguang79@qq.com>