### PR TITLE
Use nix-shell on macOS if available in auto builds script

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -364,6 +364,22 @@ os_msys2() {
 os_macos() {
     if ! which uname >/dev/null 2>&1 || [ "$(uname -s)" != "Darwin" ]; then
         return 1
+    elif which nix-env >/dev/null 2>&1; then
+        # Already in the nix-shell.
+        if [ -n "$AUTOBUILD_NIX_SHELL" ]; then
+            return 0
+        fi
+        if ! which nix-shell >/dev/null 2>&1; then
+            return 1
+        fi
+        if [ -n "$DRY_RUN" ]; then
+            return 0
+        fi
+        command="AUTOBUILD_NIX_SHELL=true"
+        command="$command;export AUTOBUILD_NIX_SHELL"
+        command="$command;$(quote "$0" "$@")"
+        exec nix-shell --pure --command "$command" \
+           -p pkg-config popplar automake
     elif which brew >/dev/null 2>&1; then
         PKGCMD=brew
         PKGARGS=install


### PR DESCRIPTION
(putting it here because I think this is the pdf-tools repo doom/melpa uses)

I use both homebrew and nix on my Mac, I use nix for most packages and brew only for its cask functionality. This adds nix support on Mac, and prioritizes it over homebrew 

Tested on my m1 MacBook, emacs29, via pdf-tools-install: 
![image](https://user-images.githubusercontent.com/71196912/138943503-4f3fa5c7-24da-4e1b-83dd-4fc40f3b3805.png)

Not sure why the CI is failing, this shouldn't affect anything on linux.

Fixes: https://github.com/politza/pdf-tools/issues/690