### PR TITLE
fix: use commands for portable POSIX shells

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 ##
 ## Installs package dependencies and builds the application.

--- a/server/autobuild
+++ b/server/autobuild
@@ -64,16 +64,7 @@ which()
     if [ -z "$1" ]; then
         return 1
     fi
-    IFS=:
-    for dir in $PATH; do
-        if [ -x "$dir/$1" ]; then
-            printf "%s" "$dir/$1"
-            unset IFS
-            return 0
-        fi
-    done
-    unset IFS
-    return 1
+    command -v "$1"
 }
 
 # Quote $@ for the shell.


### PR DESCRIPTION
This change updates the shebang to use the portable conventional form: `/usr/bin/env sh`. This was requested in #7  and currently tracked in #8. If merged, this change will continue to support POSIX standard shells that may use alternative paths (ie: not `/bin/sh`).

I updated the script's `which` function to match this and to address an issue I ran into where the prior implementation did not find executables in PATH even though they were available (not clear why, I can digger if preferred). The `command -v` method works so that's what's included here.

The change was tested on NixOS against `sh`, `ash`, and `dash`. I expect other platforms to be tested and confirmed in CI.

edit: note regarding shells tested.