### PR TITLE
fix: parameter to pdf-misc-popup-context-menu

### DIFF
--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -187,7 +187,7 @@
   :group 'pdf-misc
   (pdf-util-assert-pdf-buffer))
 
-(defun pdf-misc-popup-context-menu ()
+(defun pdf-misc-popup-context-menu (_event)
   "Popup a context menu at position."
   (interactive "@e")
   (popup-menu


### PR DESCRIPTION
A parameter `event' is required at least for emacs 29.0.
Add `_event' to pacitify compiling warning.