### PR TITLE
Fix: build on NixOS without nixpkgs in the Nix path

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -389,6 +389,10 @@ os_nixos() {
     if [ -n "$DRY_RUN" ]; then
         return 0
     fi
+    if ! nix-instantiate --eval -E "<nixpkgs>" &>/dev/null; then
+      echo "File 'nixpkgs' was not found in the Nix path. Using NixOS/nixpkgs"
+      NIX_PATH="nixpkgs=https://github.com/nixos/nixpkgs/archive/master.tar.gz:$NIX_PATH"
+    fi
     command="AUTOBUILD_NIX_SHELL=true"
     command="$command;export AUTOBUILD_NIX_SHELL"
     command="$command;$(quote "$0" "$@")"


### PR DESCRIPTION
People who use [Nix Flakes](https://nixos.wiki/wiki/Flakes) do not usually have `nixpkgs` in their `NIX_PATH`, which leads to failed builds, because `nix-shell` relies on it. I suppose some users might not have `nixpkgs` in `NIX_PATH` for other reasons also. I propose to use [NixOS/nixpkgs](https://github.com/NixOS/nixpkgs) in such cases