### PR TITLE
Make selection-style configurable

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1053,7 +1053,8 @@ Return the new annotation."
   (when (and (eq type 'text)
              (> (length edges) 1))
     (error "Edges argument should be a single edge-list for text annotations"))
-  (let* ((a (apply #'pdf-info-addannot
+  (let* ((selection-style pdf-view-selection-style)
+         (a (apply #'pdf-info-addannot
                    page
                    (if (eq type 'text)
                        (car edges)
@@ -1061,9 +1062,10 @@ Return the new annotation."
                             (apply #'append
                                    (mapcar
                                     (lambda (e)
-                                      (pdf-info-getselection page e))
+                                      (pdf-info-getselection page e selection-style))
                                     edges))))
                    type
+                   selection-style
                    nil
                    (if (not (eq type 'text)) edges)))
          (id (pdf-annot-get-id a)))

--- a/lisp/pdf-cache.el
+++ b/lisp/pdf-cache.el
@@ -332,13 +332,13 @@ See also `pdf-info-renderpage-text-regions' and
 `pdf-cache-renderpage'."
   (if pdf-cache-image-inihibit
       (apply #'pdf-info-renderpage-text-regions
-             page width single-line-p nil selection)
+             page width single-line-p nil nil selection)
     (let ((hash (sxhash
                  (format "%S" (cons 'renderpage-text-regions
                                     (cons single-line-p selection))))))
       (or (pdf-cache-get-image page width width hash)
           (let ((data (apply #'pdf-info-renderpage-text-regions
-                             page width single-line-p nil selection)))
+                             page width single-line-p nil nil selection)))
             (pdf-cache-put-image page width data hash)
             data)))))
 

--- a/lisp/pdf-isearch.el
+++ b/lisp/pdf-isearch.el
@@ -745,7 +745,7 @@ MATCH-BG LAZY-FG LAZY-BG\)."
                     (pdf-view-display-image
                      (pdf-view-create-image data :width width))))))))
       (pdf-info-renderpage-text-regions
-       page width t nil
+       page width t nil nil
        `(,fg1 ,bg1 ,@(pdf-util-scale-pixel-to-relative
                       current))
        `(,fg2 ,bg2 ,@(pdf-util-scale-pixel-to-relative

--- a/server/epdfinfo.c
+++ b/server/epdfinfo.c
@@ -1387,20 +1387,22 @@ annotation_markup_get_text_regions (PopplerPage *page, PopplerAnnotTextMarkup *a
  *
  * @param page The page of the annotation.  This is used to get the
  *             text regions and pagesize.
+ * @param selection_style The selection style.
  * @param region The region to add.
  * @param garray[in,out] An array of PopplerQuadrilateral, where the
  *              new quadrilaterals will be appended.
  */
 static void
-annotation_markup_append_text_region (PopplerPage *page, PopplerRectangle *region,
-                                      GArray *garray)
+annotation_markup_append_text_region (PopplerPage *page,
+				      PopplerSelectionStyle selection_style,
+				      PopplerRectangle *region, GArray *garray)
 {
   gdouble height;
   /* poppler_page_get_selection_region is deprecated w/o a
      replacement.  (poppler_page_get_selected_region returns a union
      of rectangles.) */
   GList *regions =
-    poppler_page_get_selection_region (page, 1.0, POPPLER_SELECTION_GLYPH, region);
+    poppler_page_get_selection_region (page, 1.0, selection_style, region);
   GList *item;
 
   poppler_page_get_size (page, NULL, &height);
@@ -1430,6 +1432,7 @@ annotation_markup_append_text_region (PopplerPage *page, PopplerRectangle *regio
  *
  * @param doc The document for which to create it.
  * @param type The type of the annotation.
+ * @param selection_style The selection style.
  * @param r The rectangle where annotation will end up on the page.
  *
  * @return The new annotation, or NULL, if the annotation type is
@@ -1437,7 +1440,7 @@ annotation_markup_append_text_region (PopplerPage *page, PopplerRectangle *regio
  */
 static PopplerAnnot*
 annotation_new (const epdfinfo_t *ctx, document_t *doc, PopplerPage *page,
-                const char *type, PopplerRectangle *r,
+                const char *type, PopplerSelectionStyle selection_style, PopplerRectangle *r,
                 const command_arg_t *rest, char **error_msg)
 {
 
@@ -1469,7 +1472,7 @@ annotation_new (const epdfinfo_t *ctx, document_t *doc, PopplerPage *page,
                                            ARG_EDGES, error_msg));
       rr->x1 *= width; rr->x2 *= width;
       rr->y1 *= height; rr->y2 *= height;
-      annotation_markup_append_text_region (page, rr, garray);
+      annotation_markup_append_text_region (page, selection_style, rr, garray);
     }
   cerror_if_not (garray->len > 0, error_msg, "%s",
                  "Unable to create empty markup annotation");
@@ -2668,6 +2671,7 @@ const command_arg_type_t cmd_addannot_spec[] =
     ARG_DOC,
     ARG_NATNUM,                 /* page number */
     ARG_STRING,                 /* type */
+    ARG_NATNUM,                 /* selection-style */
     ARG_EDGES_OR_POSITION,      /* edges or position (uses default size) */
     ARG_REST,                  /* markup regions */
   };
@@ -2679,7 +2683,8 @@ cmd_addannot (const epdfinfo_t *ctx, const command_arg_t *args)
   document_t *doc = args->value.doc;
   gint pn = args[1].value.natnum;
   const char *type_string = args[2].value.string;
-  PopplerRectangle r = args[3].value.rectangle;
+  int selection_style = args[3].value.natnum;
+  PopplerRectangle r = args[4].value.rectangle;
   int i;
   PopplerPage *page = NULL;
   double width, height;
@@ -2691,6 +2696,7 @@ cmd_addannot (const epdfinfo_t *ctx, const command_arg_t *args)
   gdouble y2;
   char *error_msg = NULL;
 
+  selection_style = xpoppler_validate_selection_style (selection_style);
   page = poppler_document_get_page (doc->pdf, pn - 1);
   perror_if_not (page, "Unable to get page %d", pn);
   poppler_page_get_size (page, &width, &height);
@@ -2704,7 +2710,7 @@ cmd_addannot (const epdfinfo_t *ctx, const command_arg_t *args)
   r.y2 = height - r.y1;
   r.y1 = height - y2;
 
-  pa = annotation_new (ctx, doc, page, type_string, &r, &args[4], &error_msg);
+  pa = annotation_new (ctx, doc, page, type_string, selection_style, &r, &args[5], &error_msg);
   perror_if_not (pa, "Creating annotation failed: %s",
                  error_msg ? error_msg : "Reason unknown");
   amap = poppler_annot_mapping_new ();
@@ -3098,6 +3104,7 @@ cmd_renderpage (const epdfinfo_t *ctx, const command_arg_t *args)
   PopplerColor bg = { 65535, 0, 0 };
   double alpha = 1.0;
   double line_width = 1.5;
+  PopplerSelectionStyle selection_style = POPPLER_SELECTION_GLYPH;
   PopplerRectangle cb = {0.0, 0.0, 1.0, 1.0};
   int i = 0;
 
@@ -3226,9 +3233,17 @@ cmd_renderpage (const epdfinfo_t *ctx, const command_arg_t *args)
                     }
 
                   poppler_page_render_selection (page, cr, r, NULL,
-                                                 POPPLER_SELECTION_GLYPH, &fg, &bg);
+                                                 selection_style, &fg, &bg);
                 }
             }
+        }
+      else if (! strcmp (keyword, ":selection-style"))
+        {
+          perror_if_not (command_arg_parse_arg (ctx, rest_args[i], &rest_arg,
+                                                ARG_NATNUM, &error_msg),
+                         "%s", error_msg);
+          ++i;
+	  selection_style = xpoppler_validate_selection_style (rest_arg.value.natnum);
         }
       else
         perror_if_not (0, "Unknown render command: %s", keyword);

--- a/server/epdfinfo.c
+++ b/server/epdfinfo.c
@@ -760,6 +760,26 @@ xpoppler_annot_text_state_string (PopplerAnnotTextState state)
     }
 };
 
+/**
+ * Validate a PopplerSelectionStyle by replacing invalid styles
+ * with a default of POPPLER_SELECTION_GLYPH.
+ *
+ * @param selection_style The selection style.
+ *
+ * @return selection_style for valid styles, otherwise POPPLER_SELECTION_GLYPH.
+ */
+static PopplerSelectionStyle
+xpoppler_validate_selection_style (int selection_style)
+{
+  switch (selection_style) {
+    case POPPLER_SELECTION_GLYPH:
+    case POPPLER_SELECTION_WORD:
+    case POPPLER_SELECTION_LINE:
+      return selection_style;
+  }
+  return POPPLER_SELECTION_GLYPH;
+}
+
 static document_t*
 document_open (const epdfinfo_t *ctx, const char *filename,
                const char *passwd, GError **gerror)
@@ -2337,14 +2357,7 @@ cmd_gettext(const epdfinfo_t *ctx, const command_arg_t *args)
   double width, height;
   gchar *text = NULL;
 
-  switch (selection_style)
-    {
-    case POPPLER_SELECTION_GLYPH: break;
-    case POPPLER_SELECTION_LINE: break;
-    case POPPLER_SELECTION_WORD: break;
-    default: selection_style = POPPLER_SELECTION_GLYPH;
-    }
-
+  selection_style = xpoppler_validate_selection_style(selection_style);
   page = poppler_document_get_page (doc, pn - 1);
   perror_if_not (page, "No such page %d", pn);
   poppler_page_get_size (page, &width, &height);
@@ -2402,14 +2415,7 @@ cmd_getselection (const epdfinfo_t *ctx, const command_arg_t *args)
   PopplerPage *page = NULL;
   int i;
 
-  switch (selection_style)
-    {
-    case POPPLER_SELECTION_GLYPH: break;
-    case POPPLER_SELECTION_LINE: break;
-    case POPPLER_SELECTION_WORD: break;
-    default: selection_style = POPPLER_SELECTION_GLYPH;
-    }
-
+  selection_style = xpoppler_validate_selection_style(selection_style);
   page = poppler_document_get_page (doc, pn - 1);
   perror_if_not (page, "No such page %d", pn);
   poppler_page_get_size (page, &width, &height);

--- a/test/pdf-info-test.el
+++ b/test/pdf-info-test.el
@@ -164,10 +164,11 @@
             annots)
       (when (memq 'markup-annotations
                   (pdf-info-features))
-        (push (pdf-info-addannot 1 '(0 0 1 1) 'squiggly '(0 0 1 1)) annots)
-        (push (pdf-info-addannot 1 '(0 0 1 1) 'highlight '(0 0 1 1)) annots)
-        (push (pdf-info-addannot 1 '(0 0 1 1) 'underline '(0 0 1 1)) annots)
-        (push (pdf-info-addannot 1 '(0 0 1 1) 'strike-out '(0 0 1 1)) annots))
+
+         (push (pdf-info-addannot 1 '(0 0 1 1) 'squiggly nil nil '(0 0 1 1)) annots)
+         (push (pdf-info-addannot 1 '(0 0 1 1) 'highlight 'word nil '(0 0 1 1)) annots)
+         (push (pdf-info-addannot 1 '(0 0 1 1) 'underline 'line nil '(0 0 1 1)) annots)
+        (push (pdf-info-addannot 1 '(0 0 1 1) 'strike-out 'glyph nil '(0 0 1 1)) annots))
       (dolist (a annots)
         (pdf-info-delannot (cdr (assq 'id a))))
       (should (= nannots (length (pdf-info-getannots)))))))


### PR DESCRIPTION
Make selection-style configurable via pdf-view-selection-style. A default value of word might be desirable, as selection is usually intended to select entire words is perceptually faster than glyph-based selection.

This affects selections and highlights, but not search. Limitation: the selection type is fixed for all currently selected regions. Selecting multiple regions with different selection styles at the same time would require storing the selection style for every region and replacing the protocol for `cmd_addannot` with a more flexible one, e.g. the keyword-based one used by `cmd_renderpage`.