### PR TITLE
Fix build-directory locating

### DIFF
--- a/lisp/pdf-tools.el
+++ b/lisp/pdf-tools.el
@@ -239,6 +239,7 @@ Returns a appropriate directory or nil.  See also
            (list default-directory
                  (expand-file-name "build/server" pdf-tools-directory)
                  (expand-file-name "server")
+                 (expand-file-name "server" pdf-tools-directory)
                  (expand-file-name "../server" pdf-tools-directory))))
 
 (defun pdf-tools-msys2-directory (&optional noninteractive-p)


### PR DESCRIPTION
* `lisp/pdf-tools.el` (`pdf-tools-locate-build-directory`): Look for `server` directory not only in `default-directory`, but also in `pdf-tools-directory`.

Fixes #90.