### PR TITLE
Add epdfinfo prereqs for openSUSE and clarify Fedora prereqs

### DIFF
--- a/README.org
+++ b/README.org
@@ -133,6 +133,21 @@ If you choose not to install from MELPA, you must substitute ~gmake~ for ~make~ 
   $ sudo dnf install make automake autoconf gcc gcc-c++ ImageMagick libpng-devel zlib-devel poppler-glib-devel
 #+END_SRC
 
+*** Installing ~epdfinfo~ Server Prerequisites On openSUSE
+:PROPERTIES:
+:ID:       07033620-fee5-4b52-a99d-e62e4b758ccc
+:END:
+For openSUSE Tumbleweed and Leap:
+#+BEGIN_SRC sh
+  $ sudo zypper install make automake autoconf gcc gcc-c++ libpng16-devel libpng16-compat-devel zlib-devel libpoppler-devel libpoppler-glib-devel glib2-devel
+#+END_SRC
+
+For openSUSE MicroOS Desktop:
+#+BEGIN_SRC sh
+  $ pkcon install make automake autoconf gcc gcc-c++ libpng16-devel libpng16-compat-devel zlib-devel libpoppler-devel libpoppler-glib-devel glib2-devel
+#+END_SRC
+
+There is one feature (following links of a PDF document by plain keystrokes) which requires imagemagick's convert utility. This requirement is optional and you may install the imagemagick package via the package manager of your choice.
 *** Installing ~epdfinfo~ Server Prerequisites On Alpine Linux
 :PROPERTIES:
 :CREATED:  [2021-12-29 Wed 18:34]

--- a/README.org
+++ b/README.org
@@ -130,9 +130,13 @@ If you choose not to install from MELPA, you must substitute ~gmake~ for ~make~ 
 :ID:       d0013822-f4d0-4354-b3db-c54ffe41ce58
 :END:
 #+BEGIN_SRC sh
-  $ sudo dnf install make automake autoconf gcc gcc-c++ ImageMagick libpng-devel zlib-devel poppler-glib-devel
+  $ sudo dnf install make automake autoconf gcc gcc-c++ libpng-devel zlib-devel poppler-glib-devel
 #+END_SRC
 
+There is one feature (following links of a PDF document by plain keystrokes) which requires imagemagick's convert utility. This requirement is optional and you may install it like so:
+#+begin_src sh
+  $ sudo dnf install imagemagick
+#+end_src
 *** Installing ~epdfinfo~ Server Prerequisites On openSUSE
 :PROPERTIES:
 :ID:       07033620-fee5-4b52-a99d-e62e4b758ccc


### PR DESCRIPTION
For openSUSE distributions, `libpng16-compat-devel` is needed so that pkg-config can find a file labeled `libpng.pc` as by default libpng16-devel would only add a file labeled `libpng16.pc`.