### PR TITLE
Use mkstemp instead of tempnam

### DIFF
--- a/server/epdfinfo.c
+++ b/server/epdfinfo.c
@@ -35,6 +35,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <errno.h>
 #include <png.h>
 #include <math.h>
@@ -346,26 +347,18 @@ strchomp (char *str)
 static char*
 mktempfile()
 {
-  char *filename = NULL;
-  int tries = 3;
-  while (! filename && tries-- > 0)
+  char template[] = "/tmp/epdfinfoXXXXXX";
+  char *filename = malloc(sizeof(template));
+  memcpy(filename, template, sizeof(template));
+  int fd = mkstemp(filename);
+  if (fd == -1)
     {
-
-      filename =  tempnam(NULL, "epdfinfo");
-      if (filename)
-        {
-          int fd = open(filename, O_CREAT | O_EXCL | O_RDONLY, S_IRWXU);
-          if (fd > 0)
-            close (fd);
-          else
-            {
-              free (filename);
-              filename = NULL;
-            }
-        }
+      fprintf (stderr, "Unable to create tempfile");
+      free(filename);
+      filename = NULL;
     }
-  if (! filename)
-    fprintf (stderr, "Unable to create tempfile");
+  else
+    close(fd);
 
   return filename;
 }


### PR DESCRIPTION
When building epdfinfo, there is a warning
```
build/server/epdfinfo.c:354: warning: the use of `tempnam' is dangerous, better use `mkstemp'
```

This PR changes `mktempfile()` to use `mkstemp()` instead of `tempnam()`.