### PR TITLE
fix: disable qt-workaround in Emacs 27>=

### DIFF
--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -305,7 +305,7 @@ error."
       (setq pdf-info--queue (tq-create proc))))
   pdf-info--queue)
 
-(advice-add 'tq-process-buffer :around #'pdf-info--tq-workaround)
+(when (< emacs-major-version 27) (advice-add 'tq-process-buffer :around #'pdf-info--tq-workaround))
 (defun pdf-info--tq-workaround (orig-fun tq &rest args)
   "Fix a bug in trunk where the wrong callback gets called.
 


### PR DESCRIPTION
The bug is fixed upstream in Emacs 27 https://debbugs.gnu.org/cgi/bugreport.cgi?bug=19016

Fixes: #118