### PR TITLE
disable pixel-scroll-precision-mode locally if enabled in pdf-view

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -334,6 +334,10 @@ PNG images in Emacs buffers."
       (setq-local mwheel-scroll-down-function
                   #'pdf-view-scroll-down-or-previous-page))
 
+  ;; Disable pixel-scroll-precision-mode locally if enabled
+  (if (bound-and-true-p pixel-scroll-precision-mode)
+      (set (make-local-variable 'pixel-scroll-precision-mode) nil))
+
   ;; Clearing overlays
   (add-hook 'change-major-mode-hook
             (lambda ()


### PR DESCRIPTION
Closes #56 

This change disables the emacs 29 `pixel-scroll-precision-mode` (if enabled) which interferes with the pdf-tools scrolling mechanism. I think the `pixel-scroll-precision-mode` does not make sense in the context of the pdf-view mode, which does pixel based scrolling anyways.

After this change, scrolling in a pdf-view buffer should work again with `pixel-scroll-precision-mode` enabled.