### PR TITLE
Fix revert-buffer for remote files

### DIFF
--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -1031,7 +1031,11 @@ Manually opened documents are never closed automatically."
 Returns t, if the document was actually open, otherwise nil.
 This command is rarely needed, see also `pdf-info-open'."
   (let* ((pdf (pdf-info--normalize-file-or-buffer file-or-buffer))
-         (buffer (find-buffer-visiting pdf)))
+         (buffer (cond
+                  ((not file-or-buffer) (current-buffer))
+                  ((bufferp file-or-buffer) file-or-buffer)
+                  ((stringp file-or-buffer)
+                   (find-buffer-visiting file-or-buffer)))))
     (prog1
         (pdf-info-query 'close pdf)
       (if (buffer-live-p buffer)

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -479,6 +479,12 @@ operating on a local copy of a remote file."
         (when (file-exists-p tempfile)
           (delete-file tempfile))))))
 
+(defun pdf-view--after-revert ()
+  "Reload the local copy in case of a remote file, and close the document."
+  (when pdf-view--buffer-file-name
+    (write-region nil nil pdf-view--buffer-file-name nil 'no-message))
+  (pdf-info-close))
+
 (defun pdf-view-revert-buffer (&optional ignore-auto noconfirm)
   "Revert buffer while preserving current modes.
 
@@ -492,7 +498,7 @@ Optional parameters IGNORE-AUTO and NOCONFIRM are defined as in
   (let ((revert-buffer-function (when (fboundp #'revert-buffer--default)
                                   #'revert-buffer--default))
         (after-revert-hook
-         (cons #'pdf-info-close
+         (cons #'pdf-view--after-revert
                after-revert-hook)))
     (prog1
         (revert-buffer ignore-auto noconfirm 'preserve-modes)


### PR DESCRIPTION
Fixes #126 

There are two issues with `revert-buffer` for remote files:

* `revert-buffer` does not update the local temporary copy of the remote file (`pdf-view--buffer-file-name`). Since `revert-buffer--default` does in fact renew contents of the current buffer when visiting a remote file, the fix is the matter of flushing the buffer contents into the temporary file, exactly how it's done in `pdf-view-mode`:
https://github.com/vedang/pdf-tools/blob/386dca5b2d078ba691eefe230478a440ee1f7b16/lisp/pdf-view.el#L321-L322

* `revert-buffer` relies on `pdf-info-close` to run `pdf-info-close-document-hook`, which clears the image and data caches, so they can be rebuilt from the new file. `pdf-info-close` first normalizes the file using `pdf-info--normalize-file-or-buffer`, which returns `pdf-view--buffer-file-name`, and then tries to run the hook in the buffer visiting that file. Since there is not going to be a buffer visiting the local temporary file (normally), no hooks are actually ran. Fixed by deriving the buffer directly from the `file-or-buffer` argument:

```
(cond
  ((not file-or-buffer) (current-buffer))
  ((bufferp file-or-buffer) file-or-buffer)
  ((stringp file-or-buffer) (find-buffer-visiting file-or-buffer)))
```