### PR TITLE
compile epdfinfo on Fedora SilverBlue

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -258,7 +258,7 @@ os_fedora() {
         return 1
     fi
     PKGCMD=dnf
-    PKGARGS=install
+    PKGARGS="install -y"
     PACKAGES="autoconf
               automake
               gcc


### PR DESCRIPTION
Fedora SilverBlue don't have dnf. epdfinfo should be compiled in a [toolbox](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/). And often emacs is installed by [flatpak](https://flathub.org/apps/details/org.gnu.emacs), we have to run autobuild and the server with `flatpak-spawn --host`