### PR TITLE
synctex_parser: fix vasprintf() not exists in non-GNU environment

### DIFF
--- a/server/configure.ac
+++ b/server/configure.ac
@@ -84,7 +84,7 @@ AC_C_BIGENDIAN
 # Checks for library functions.
 AC_FUNC_ERROR_AT_LINE
 AC_FUNC_STRTOD
-AC_CHECK_FUNCS([strcspn strtol getline])
+AC_CHECK_FUNCS([strcspn strtol getline vasprintf])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/server/synctex_parser.c
+++ b/server/synctex_parser.c
@@ -8415,9 +8415,7 @@ static int _synctex_updater_print(synctex_updater_p updater, const char * format
     }
     return result;
 }
-#if defined(_MSC_VER)
-#include <stdio.h>
-#include <stdlib.h>
+#ifndef HAVE_VASPRINTF
 #include <stdarg.h>
 
 static int vasprintf(char **ret,
@@ -8425,11 +8423,11 @@ static int vasprintf(char **ret,
                      va_list ap)
 {
     int len;
-    len = _vsnprintf(NULL, 0, format, ap);
+    len = vsnprintf(NULL, 0, format, ap);
     if (len < 0) return -1;
     *ret = malloc(len + 1);
     if (!*ret) return -1;
-    _vsnprintf(*ret, len+1, format, ap);
+    vsnprintf(*ret, len + 1, format, ap);
     (*ret)[len] = '\0';
     return len;
 }


### PR DESCRIPTION
The vasprintf() is a GNU extension function, missed in non-GNU build environment, so we define it.

Without this change, there will have error message when build with `clang`:
```
./autogen.sh
./configure CC=clang
make
```
Will get errors:
```
synctex_parser.c:8448:13: error: call to undeclared function 'vasprintf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (vasprintf(&buffer, format, va) < 0) {
```
