### PR TITLE
Don't depend on gcc when building with `nix-shell`

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -383,7 +383,7 @@ os_nixos() {
     command="AUTOBUILD_NIX_SHELL=true"
     command="$command;export AUTOBUILD_NIX_SHELL"
     command="$command;$(quote "$0" "$@")"
-    exec nix-shell --pure --command "$command" \
+    exec nix-shell --pure --run "$command" \
          -p gcc gnumake automake autoconf pkgconfig libpng zlib poppler
 }
 

--- a/server/autobuild
+++ b/server/autobuild
@@ -384,7 +384,7 @@ os_nixos() {
     command="$command;export AUTOBUILD_NIX_SHELL"
     command="$command;$(quote "$0" "$@")"
     exec nix-shell --pure --run "$command" \
-         -p gcc gnumake automake autoconf pkgconfig libpng zlib poppler
+         -p automake autoconf pkgconfig libpng zlib poppler
 }
 
 # Gentoo

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -91,7 +91,6 @@
   `(pdf-test-with-pdf "encrypted.pdf" ,@body))
 
 ;; ---
-(require 'f)
 (require 'undercover)
 (undercover "lisp/*.el")
 (require 'let-alist)


### PR DESCRIPTION
`nix-shell` already sets a C compiler. For instance, it uses Clang on Darwin.