### PR TITLE
Fix: remove execute permisions from temp files

### DIFF
--- a/server/epdfinfo.c
+++ b/server/epdfinfo.c
@@ -354,7 +354,7 @@ mktempfile()
       filename =  tempnam(NULL, "epdfinfo");
       if (filename)
         {
-          int fd = open(filename, O_CREAT | O_EXCL | O_RDONLY, S_IRWXU);
+          int fd = open(filename, O_CREAT | O_EXCL | O_RDONLY, S_IRUSR | S_IWUSR);
           if (fd > 0)
             close (fd);
           else


### PR DESCRIPTION
They aren't necessary.

Fixes #138.