### PR TITLE
Address some byte-compiler warnings

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -524,12 +524,11 @@ the variable is nil and this function is called again."
            (union (cl-union (cl-union changed inserted :test 'pdf-annot-equal)
                             deleted :test 'pdf-annot-equal))
            (closure (lambda (arg)
-                      (cl-ecase arg
+                      (cl-case arg
                         (:inserted (copy-sequence inserted))
                         (:changed (copy-sequence changed))
                         (:deleted (copy-sequence deleted))
-                        (t (copy-sequence union))
-                        (nil nil))))
+                        (t (copy-sequence union)))))
            (pages (mapcar (lambda (a) (pdf-annot-get a 'page)) union)))
       (when union
         (unwind-protect
@@ -1464,7 +1463,7 @@ annotation's contents and otherwise `org-mode'."
   "Finalize edit-operations on an Annotation.
 
 If DO-SAVE is t, save the changes to annotation content without
-asking. If DO-SAVE is 'ask, check if the user if contents should
+asking. If DO-SAVE is `ask', check if the user if contents should
 be saved.
 
 If DO-KILL is t, kill all windows displaying the annotation

--- a/lisp/pdf-sync.el
+++ b/lisp/pdf-sync.el
@@ -113,14 +113,14 @@ position in the original tex file."
 \\<pdf-sync-minor-mode-map>
 This works via SyncTeX, which means the TeX sources need to have
 been compiled with `--synctex=1'.  In AUCTeX this can be done by
-setting `TeX-source-correlate-method' to 'synctex \(before AUCTeX
-is loaded\) and enabling `TeX-source-correlate-mode'.
+setting `TeX-source-correlate-method' to `synctex' (before AUCTeX
+is loaded) and enabling `TeX-source-correlate-mode'.
 
-Then \\[pdf-sync-backward-search-mouse] in the PDF buffer will open the
-corresponding TeX location.
+Then \\[pdf-sync-backward-search-mouse] in the PDF buffer will
+open the corresponding TeX location.
 
 If AUCTeX is your preferred tex-mode, this library arranges to
-bind `pdf-sync-forward-display-pdf-key' \(the default is `C-c C-g'\)
+bind `pdf-sync-forward-display-pdf-key' (the default is `C-c C-g')
 to `pdf-sync-forward-search' in `TeX-source-correlate-map'.  This
 function displays the PDF page corresponding to the current
 position in the TeX buffer.  This function only works together
@@ -758,7 +758,7 @@ The first such filename is returned, or nil if none was found."
                   (let ((syncname (match-string-no-properties 1)))
                     (when (and (file-exists-p syncname)
                                (file-equal-p filename syncname))
-                      (goto-char (point-at-bol))
+                      (goto-char (line-beginning-position))
                       (throw 'found syncname))))
                 (setq end beg
                       beg (point-min))

--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -648,7 +648,7 @@ Signal an error, if color is invalid."
       (unless values
         (signal 'wrong-type-argument (list 'color-defined-p color)))
       (apply #'format "#%02x%02x%02x"
-             (mapcar (lambda (c) (lsh c -8))
+             (mapcar (lambda (c) (ash c -8))
                      values)))))
 
 (defun pdf-util-highlight-regexp-in-string (regexp string &optional face)
@@ -668,6 +668,8 @@ string."
          (point)
          'face (or face 'match))))
     (buffer-string)))
+
+(autoload 'list-colors-duplicates "facemenu")
 
 (defun pdf-util-color-completions ()
   "Return a fontified list of defined colors."
@@ -1059,14 +1061,14 @@ replacement string.
 IN-FILE coordinates. Each such rectangle triggers one execution
 of the last commands given earlier in SPEC. E.g. a call like
 
-\(pdf-util-convert
-       image-file out-file
-       :foreground \"black\"
-       :background \"white\"
-       :commands '(\"-fill\" \"%f\" \"-draw\" \"rectangle %x,%y,%X,%Y\")
-       :apply '((0 0 10 10) (10 10 20 20))
-       :commands '(\"-fill\" \"%b\" \"-draw\" \"rectangle %x,%y,%X,%Y\")
-       :apply '((10 0 20 10) (0 10 10 20)))
+  (pdf-util-convert
+   image-file out-file
+   :foreground \"black\"
+   :background \"white\"
+   :commands \\='(\"-fill\" \"%f\" \"-draw\" \"rectangle %x,%y,%X,%Y\")
+   :apply \\='((0 0 10 10) (10 10 20 20))
+   :commands \\='(\"-fill\" \"%b\" \"-draw\" \"rectangle %x,%y,%X,%Y\")
+   :apply \\='((10 0 20 10) (0 10 10 20)))
 
 would draw a 4x4 checkerboard pattern in the left corner of the
 image, while leaving the rest of it as it was.

--- a/lisp/pdf-virtual.el
+++ b/lisp/pdf-virtual.el
@@ -735,8 +735,8 @@ PAGE should be a page-number."
        (defun ,fn ,(cons base-fn-arg arglist)
          ,(format "%sPDF virtual adapter to `%s'.
 
-This function delegates to `%s', unless the FILE-OR-BUFFER
-argument denotes a VPDF document."
+This function delegates to `%s',
+unless the FILE-OR-BUFFER argument denotes a VPDF document."
                   (if doc (concat doc "\n\n") "")
                   base-fn
                   base-fn)


### PR DESCRIPTION
### Version

<details>
<summary>Emacs 29 configuration</summary>

```
In GNU Emacs 29.0.50 (build 1, x86_64-pc-linux-gnu, X toolkit, cairo
 version 1.16.0, Xaw3d scroll bars) of 2022-09-15 built on tia
Repository revision: 3c1579697ff03d3991b41ead503211cffac0998f
Repository branch: master
Windowing system distributor 'The X.Org Foundation', version 11.0.12101004
System Description: Debian GNU/Linux bookworm/sid

Configured using:
 'configure 'CFLAGS=-Og -ggdb3' -C --prefix=/home/blc/.local
 --enable-checking=structs --with-file-notification=yes
 --with-x-toolkit=lucid --with-x'

Configured features:
ACL CAIRO DBUS FREETYPE GIF GLIB GMP GNUTLS GPM GSETTINGS HARFBUZZ JPEG
JSON LCMS2 LIBOTF LIBSELINUX LIBSYSTEMD LIBXML2 M17N_FLT MODULES NOTIFY
INOTIFY PDUMPER PNG RSVG SECCOMP SOUND SQLITE3 THREADS TIFF
TOOLKIT_SCROLL_BARS WEBP X11 XAW3D XDBE XIM XINPUT2 XPM LUCID ZLIB

Important settings:
  value of $LANG: en_IE.UTF-8
  value of $XMODIFIERS: @im=ibus
  locale-coding-system: utf-8-unix

Major mode: Lisp Interaction

Minor modes in effect:
  tooltip-mode: t
  global-eldoc-mode: t
  eldoc-mode: t
  show-paren-mode: t
  electric-indent-mode: t
  mouse-wheel-mode: t
  tool-bar-mode: t
  menu-bar-mode: t
  file-name-shadow-mode: t
  global-font-lock-mode: t
  font-lock-mode: t
  blink-cursor-mode: t
  line-number-mode: t
  indent-tabs-mode: t
  transient-mark-mode: t
  auto-composition-mode: t
  auto-encryption-mode: t
  auto-compression-mode: t

Load-path shadows:
None found.

Features:
(shadow sort mail-extr emacsbug message mailcap yank-media puny dired
dired-loaddefs rfc822 mml mml-sec password-cache epa derived epg rfc6068
epg-config gnus-util text-property-search time-date subr-x mm-decode
mm-bodies mm-encode mail-parse rfc2231 mailabbrev gmm-utils mailheader
cl-loaddefs cl-lib sendmail rfc2047 rfc2045 ietf-drums mm-util
mail-prsvr mail-utils rmc iso-transl tooltip eldoc paren electric
uniquify ediff-hook vc-hooks lisp-float-type elisp-mode mwheel
term/x-win x-win term/common-win x-dnd tool-bar dnd fontset image
regexp-opt fringe tabulated-list replace newcomment text-mode lisp-mode
prog-mode register page tab-bar menu-bar rfn-eshadow isearch easymenu
timer select scroll-bar mouse jit-lock font-lock syntax font-core
term/tty-colors frame minibuffer nadvice seq simple cl-generic
indonesian philippine cham georgian utf-8-lang misc-lang vietnamese
tibetan thai tai-viet lao korean japanese eucjp-ms cp51932 hebrew greek
romanian slovak czech european ethiopic indian cyrillic chinese
composite emoji-zwj charscript charprop case-table epa-hook
jka-cmpr-hook help abbrev obarray oclosure cl-preloaded button loaddefs
faces cus-face macroexp files window text-properties overlay sha1 md5
base64 format env code-pages mule custom widget keymap
hashtable-print-readable backquote threads dbusbind inotify lcms2
dynamic-setting system-font-setting font-render-setting cairo x-toolkit
xinput2 x multi-tty make-network-process emacs)
```

</details>

### Warnings

<details>
<summary>Warnings before patch</summary>

```
-*- mode: compilation; default-directory: "~/.emacs.d/src/pdf-tools/" -*-
Compilation started at Fri Sep 16 20:51:48

rm lisp/*.elc; emacs -Q -batch -f package-initialize -L lisp -f batch-byte-compile lisp/*.el

In toplevel form:
lisp/pdf-annot.el:76:12: Warning: defcustom for ‘pdf-annot-default-annotation-properties’ has syntactically odd type ‘...’
lisp/pdf-annot.el:527:24: Error: Misplaced t or ‘otherwise’ clause

In pdf-sync-minor-mode:
lisp/pdf-sync.el:111:2: Warning: docstring has wrong usage of unescaped single quotes (use \= or different quoting)

In pdf-sync-synctex-file-name:
lisp/pdf-sync.el:761:35: Warning: ‘point-at-bol’ is an obsolete function (as of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.

In pdf-util-hexcolor:
lisp/pdf-util.el:651:35: Warning: avoid `lsh'; use `ash' instead

In pdf-util-convert:
lisp/pdf-util.el:1017:2: Warning: docstring has wrong usage of unescaped single quotes (use \= or different quoting)

In pdf-view-registerv-make:
lisp/pdf-view.el:1652:4: Warning: ‘registerv-make’ is an obsolete function (as of 27.1); Use your own type with methods on register-val-(insert|describe|jump-to)

In pdf-virtual-getattachment-from-annot:
lisp/pdf-virtual.el:964:2: Warning: docstring wider than 80 characters

In pdf-virtual-synctex-forward-search:
lisp/pdf-virtual.el:987:2: Warning: docstring wider than 80 characters

In pdf-virtual-synctex-backward-search:
lisp/pdf-virtual.el:991:2: Warning: docstring wider than 80 characters

Compilation exited abnormally with code 1 at Fri Sep 16 20:51:50
```

</details>

<details>
<summary>Warnings after patch</summary>

```
-*- mode: compilation; default-directory: "~/.emacs.d/src/pdf-tools/" -*-
Compilation started at Fri Sep 16 21:14:57

rm lisp/*.elc; emacs -Q -batch -f package-initialize -L lisp -f batch-byte-compile lisp/*.el

In toplevel form:
lisp/pdf-annot.el:76:12: Warning: defcustom for ‘pdf-annot-default-annotation-properties’ has syntactically odd type ‘...’

In pdf-annot-print-annotation-latex:
lisp/pdf-annot.el:1374:19: Warning: ‘org-latex-create-formula-image-program’ is an obsolete variable (as of 9.0); use ‘org-preview-latex-default-process’ instead.

In pdf-view-registerv-make:
lisp/pdf-view.el:1652:4: Warning: ‘registerv-make’ is an obsolete function (as of 27.1); Use your own type with methods on register-val-(insert|describe|jump-to)

Compilation finished at Fri Sep 16 21:14:59
```

</details>

### ChangeLog

Address some byte-compiler warnings

* `lisp/pdf-annot.el` (`pdf-annot-run-modified-hooks`): Use `cl-case` instead of `cl-ecase`, as the latter does not support `t`/`otherwise` clauses.  Remove `nil` clause which never matches.  See https://bugs.gnu.org/51368.
(`pdf-annot-edit-contents-finalize`):
* `lisp/pdf-sync.el` (`pdf-sync-minor-mode`): Mark up symbols `` `like-this' ``, to avoid having the apostrophe interpreted as a closing single quote.  Remove redundant backslashes.
(`pdf-sync-synctex-file-name`): Use `line-beginning-position` in place of `point-at-bol`, which is deprecated in Emacs 29.
* `lisp/pdf-util.el`: Autoload `list-colors-duplicates` before its use in `pdf-util-color-completions`, as `facemenu` is not preloaded since Emacs 28.
(`pdf-util-hexcolor`): Use `ash` in place of `lsh`, which is deprecated in Emacs 29.
(`pdf-util-convert`): Fix docstring markup and indentation.
* `lisp/pdf-virtual.el` (`pdf-virtual-define-adapter`): Refill generated docstring to avoid exceeding 80 column warning threshold.