### PR TITLE
Fix nix-shell pkg-config dependency name

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -384,7 +384,7 @@ os_nixos() {
     command="$command;export AUTOBUILD_NIX_SHELL"
     command="$command;$(quote "$0" "$@")"
     exec nix-shell --pure --run "$command" \
-         -p automake autoconf pkgconfig libpng zlib poppler
+         -p automake autoconf pkg-config libpng zlib poppler
 }
 
 # Gentoo


### PR DESCRIPTION
Recently nixpkgs removed the `pkgconfig` alias [1], which broke the build with nix-shell.

[1] https://github.com/NixOS/nixpkgs/pull/192681