### PR TITLE
fix: `cl-ecase` does not support otherwise case

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -528,7 +528,6 @@ the variable is nil and this function is called again."
                         (:inserted (copy-sequence inserted))
                         (:changed (copy-sequence changed))
                         (:deleted (copy-sequence deleted))
-                        (t (copy-sequence union))
                         (nil nil))))
            (pages (mapcar (lambda (a) (pdf-annot-get a 'page)) union)))
       (when union


### PR DESCRIPTION
I have ran the test suite and opened a pdf with emacs, but this change has the smell of breaking something I don't understand.

Without it I cannot evaluate the buffer `pdf-annot.el` file without getting this: `(error Eager macro-expansion failure: (error "Misplaced t or ‘otherwise’ clause"))`

GNU Emacs 29.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.24, cairo version 1.16.0) of 2022-09-25