### PR TITLE
Solved critical pdf-annot error

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -524,12 +524,11 @@ the variable is nil and this function is called again."
            (union (cl-union (cl-union changed inserted :test 'pdf-annot-equal)
                             deleted :test 'pdf-annot-equal))
            (closure (lambda (arg)
-                      (cl-ecase arg
+                      (cl-case arg
                         (:inserted (copy-sequence inserted))
                         (:changed (copy-sequence changed))
                         (:deleted (copy-sequence deleted))
-                        (t (copy-sequence union))
-                        (nil nil))))
+                        (t (copy-sequence union)))))
            (pages (mapcar (lambda (a) (pdf-annot-get a 'page)) union)))
       (when union
         (unwind-protect


### PR DESCRIPTION
Hi. First of all thank you for your effort maintaining `pdf-tools`.

I have found and patched a critical error which breaks `pdf-annot` in Emacs 29.0.50.

### Error

After installing `pdf-tools` following the tutorial, opening a PDF fails with the error below.

<details><summary>ERROR MESSAGE</summary>
<p>

```
Debugger entered--Lisp error: (error "Eager macro-expansion failure: (error \"Misplaced t or ‘otherwise’ clause\")")
  signal(error ("Eager macro-expansion failure: (error \"Misplaced t or ‘otherwise’ clause\")"))
  error("Eager macro-expansion failure: %S" (error "Misplaced t or ‘otherwise’ clause"))
  internal-macroexpand-for-load((defalias 'pdf-annot-run-modified-hooks #'(lambda (&optional operation &rest annotations) "Run `pdf-annot-modified-functions' using OPERATION on ANNOTATIONS.\n\nOPERATION should be one of nil, :change, :insert or :delete.  If\nnil, annotations should be empty.\n\nRedisplay modified pages.\n\nIf `p..." (unless (memq operation '(nil :insert :change :delete)) (error "Invalid operation: %s" operation)) (when (and (null operation) annotations) (error "Missing operation argument")) (when operation (let ((list (plist-get pdf-annot-delayed-modified-annotations operation))) (dolist (a annotations) (cl-pushnew a list :test ...)) (setq pdf-annot-delayed-modified-annotations (plist-put pdf-annot-delayed-modified-annotations operation list)))) (unless pdf-annot-inhibit-modification-hooks (let* ((changed (plist-get pdf-annot-delayed-modified-annotations :change)) (inserted (mapcar (lambda (a) (or (car (cl-member a changed :test 'pdf-annot-equal)) a)) (plist-get pdf-annot-delayed-modified-annotations :insert))) (deleted (plist-get pdf-annot-delayed-modified-annotations :delete)) (union (cl-union (cl-union changed inserted :test 'pdf-annot-equal) deleted :test 'pdf-annot-equal)) (closure (lambda (arg) (cl-ecase arg (:inserted (copy-sequence inserted)) (:changed (copy-sequence changed)) (:deleted (copy-sequence deleted)) (t (copy-sequence union)) (nil nil)))) (pages (mapcar (lambda (a) (pdf-annot-get a 'page)) union))) (when union (unwind-protect (run-hook-with-args 'pdf-annot-modified-functions closure) (setq pdf-annot-delayed-modified-annotations nil) (apply #'pdf-view-redisplay-pages pages))))))) t)
  eval-buffer(#<buffer  *load*> nil "/home/antonio/.emacs.d/straight/build/pdf-tools/pdf-annot.el" nil t)  ; Reading at buffer position 21369
  load-with-code-conversion("/home/antonio/.emacs.d/straight/build/pdf-tools/pdf-annot.el" "/home/antonio/.emacs.d/straight/build/pdf-tools/pdf-annot.el" nil t)
  pdf-annot-minor-mode(1)
  pdf-tools-set-modes-enabled(t nil)
  pdf-tools-enable-minor-modes()
  run-hooks(change-major-mode-after-body-hook special-mode-hook pdf-view-mode-hook)
  apply(run-hooks (change-major-mode-after-body-hook special-mode-hook pdf-view-mode-hook))
  run-mode-hooks(pdf-view-mode-hook)
  pdf-view-mode()
  set-auto-mode-0(pdf-view-mode nil)
  #f(compiled-function (&optional keep-mode-if-same) "Select major mode appropriate for current buffer.\n\nTo find the right major mode, this function checks for a -*- mode tag\nchecks for a `mode:' entry in the Local Variables section of the file,\nchecks if there an `auto-mode-alist' entry in `.dir-locals.el',\nchecks if it uses an interpreter listed in `interpreter-mode-alist',\nmatches the buffer beginning against `magic-mode-alist',\ncompares the file name against the entries in `auto-mode-alist',\nthen matches the buffer beginning against `magic-fallback-mode-alist'.\n\nIf `enable-local-variables' is nil, or if the file name matches\n`inhibit-local-variables-regexps', this function does not check\nfor any mode: tag anywhere in the file.  If `local-enable-local-variables'\nis nil, then the only mode: tag that can be relevant is a -*- one.\n\nIf the optional argument KEEP-MODE-IF-SAME is non-nil, then we\nset the major mode only if that would change it.  In other words\nwe don't actually set it to the same mode the buffer already has." #<bytecode 0x14c9323d79efc7ab>)()
  apply(#f(compiled-function (&optional keep-mode-if-same) "Select major mode appropriate for current buffer.\n\nTo find the right major mode, this function checks for a -*- mode tag\nchecks for a `mode:' entry in the Local Variables section of the file,\nchecks if there an `auto-mode-alist' entry in `.dir-locals.el',\nchecks if it uses an interpreter listed in `interpreter-mode-alist',\nmatches the buffer beginning against `magic-mode-alist',\ncompares the file name against the entries in `auto-mode-alist',\nthen matches the buffer beginning against `magic-fallback-mode-alist'.\n\nIf `enable-local-variables' is nil, or if the file name matches\n`inhibit-local-variables-regexps', this function does not check\nfor any mode: tag anywhere in the file.  If `local-enable-local-variables'\nis nil, then the only mode: tag that can be relevant is a -*- one.\n\nIf the optional argument KEEP-MODE-IF-SAME is non-nil, then we\nset the major mode only if that would change it.  In other words\nwe don't actually set it to the same mode the buffer already has." #<bytecode 0x14c9323d79efc7ab>) nil)
  so-long--set-auto-mode(#f(compiled-function (&optional keep-mode-if-same) "Select major mode appropriate for current buffer.\n\nTo find the right major mode, this function checks for a -*- mode tag\nchecks for a `mode:' entry in the Local Variables section of the file,\nchecks if there an `auto-mode-alist' entry in `.dir-locals.el',\nchecks if it uses an interpreter listed in `interpreter-mode-alist',\nmatches the buffer beginning against `magic-mode-alist',\ncompares the file name against the entries in `auto-mode-alist',\nthen matches the buffer beginning against `magic-fallback-mode-alist'.\n\nIf `enable-local-variables' is nil, or if the file name matches\n`inhibit-local-variables-regexps', this function does not check\nfor any mode: tag anywhere in the file.  If `local-enable-local-variables'\nis nil, then the only mode: tag that can be relevant is a -*- one.\n\nIf the optional argument KEEP-MODE-IF-SAME is non-nil, then we\nset the major mode only if that would change it.  In other words\nwe don't actually set it to the same mode the buffer already has." #<bytecode 0x14c9323d79efc7ab>))
  apply(so-long--set-auto-mode #f(compiled-function (&optional keep-mode-if-same) "Select major mode appropriate for current buffer.\n\nTo find the right major mode, this function checks for a -*- mode tag\nchecks for a `mode:' entry in the Local Variables section of the file,\nchecks if there an `auto-mode-alist' entry in `.dir-locals.el',\nchecks if it uses an interpreter listed in `interpreter-mode-alist',\nmatches the buffer beginning against `magic-mode-alist',\ncompares the file name against the entries in `auto-mode-alist',\nthen matches the buffer beginning against `magic-fallback-mode-alist'.\n\nIf `enable-local-variables' is nil, or if the file name matches\n`inhibit-local-variables-regexps', this function does not check\nfor any mode: tag anywhere in the file.  If `local-enable-local-variables'\nis nil, then the only mode: tag that can be relevant is a -*- one.\n\nIf the optional argument KEEP-MODE-IF-SAME is non-nil, then we\nset the major mode only if that would change it.  In other words\nwe don't actually set it to the same mode the buffer already has." #<bytecode 0x14c9323d79efc7ab>) nil)
  set-auto-mode()
  normal-mode(t)
  after-find-file(nil t)
  find-file-noselect-1(#<buffer Daniel O'Connor - The intuition behind calculus on manifolds.pdf> "~/Daniel O'Connor - The intuition behind calculus on manifolds.pdf" nil nil "~/Daniel O'Connor - The intuition behind calculus on manifolds.pdf" (9702405 66312))
  find-file-noselect("/home/antonio/Daniel O'Connor - The intuition behind calculus on manifolds.pdf" nil nil t)
  find-file("/home/antonio/Daniel O'Connor - The intuition behind calculus on manifolds.pdf" t)
  funcall-interactively(find-file "/home/antonio/Daniel O'Connor - The intuition behind calculus on manifolds.pdf" t)
  call-interactively(find-file nil nil)
  command-execute(find-file)
```

</p>
</details>

After attempting to open the PDF a second time, the PDF will be displayed but all of *pdf-annot* is unavailable. Attempting to execute `pdf-annot.el` raises the same error.

### Minimal config

The following is a minimal init.el I have used to reproduce the error in my machine.

```
;; straight.el
(defvar bootstrap-version)
(let ((bootstrap-file
       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
      (bootstrap-version 5))
  (unless (file-exists-p bootstrap-file)
    (with-current-buffer
        (url-retrieve-synchronously
         "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
         'silent 'inhibit-cookies)
      (goto-char (point-max))
      (eval-print-last-sexp)))
  (load bootstrap-file nil 'nomessage))

;; pdf-tools
(straight-use-package 'tablist)
(straight-use-package 'pdf-tools)
(require 'pdf-tools)
(pdf-tools-install)
(pdf-loader-install)
```

### Solution

The error message narrowed the error to `pdf-annot-run-modified-hooks`.

In particular, there seems to be a `Misplaced t or ‘otherwise’ clause` in the [`cl-ecase` macro call at line 27 of `pdf-annot.el`](https://github.com/vedang/pdf-tools/blob/1a0a30c54dc3effdba4781a2983115d4b6993260/lisp/pdf-annot.el#L527).

```
           (closure (lambda (arg)
                        (cl-ecase arg
                          (:inserted (copy-sequence inserted))
                          (:changed (copy-sequence changed))
                          (:deleted (copy-sequence deleted))
                          (t (copy-sequence union))
                          (nil nil))))
```

The error is caused by having the `t` block *before* `(nil nil)`. I have fixed the issue by replacing the block above the one that follows, and now `pdf-annot` works perfectly for me.

The change does the following:

1. Place the `(t ...)` block at the end of the macro
2. Remove the `(nil nil)` case from the declaration, and *replace* the `cl-ecase` macro by a `cl-case` macro, so that when the `nil` case is not matched *nothing happens* (as I suppose was intended) and the macro returns `nil`, instead of raising an error

```
           (closure (lambda (arg)
                      (cl-case arg
                        (:inserted (copy-sequence inserted))
                        (:changed (copy-sequence changed))
                        (:deleted (copy-sequence deleted))
                        (t (copy-sequence union)))))
```