### PR TITLE
Fix misuse of cl-ecase

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -524,12 +524,12 @@ the variable is nil and this function is called again."
            (union (cl-union (cl-union changed inserted :test 'pdf-annot-equal)
                             deleted :test 'pdf-annot-equal))
            (closure (lambda (arg)
-                      (cl-ecase arg
-                        (:inserted (copy-sequence inserted))
-                        (:changed (copy-sequence changed))
-                        (:deleted (copy-sequence deleted))
-                        (t (copy-sequence union))
-                        (nil nil))))
+                      (when arg
+                        (cl-case arg
+                          (:inserted (copy-sequence inserted))
+                          (:changed (copy-sequence changed))
+                          (:deleted (copy-sequence deleted))
+                          (t (copy-sequence union))))))
            (pages (mapcar (lambda (a) (pdf-annot-get a 'page)) union)))
       (when union
         (unwind-protect


### PR DESCRIPTION
The cl-ecase macro does not support default cases (‘otherwise’ or ‘t’), and the cl-case macro requires the default case to be the last clause, [which a recent change to Emacs rendered a macro expansion error][1], thus preventing the module from loading (and potentially signalling error in the init process).

Furthermore, cl-ecase expands to a cl-case form with a trailing special flag clause, so the appearance of a ‘t’ or ‘otherwise’ clause in a cl-ecase call will always result in this error being triggered.

I thus replace the apparently futile call to cl-ecase with an equivalent null check and a call to cl-case, which fixes both issues. I replaced cl-ecase with cl-case because the former form had both a t-check and a nil-check, which meant the error case was impossible to be triggered.

I wasn't able to run the tests, but I tested annotating a PDF with this change active and it worked alright.

[1]: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51368