### PR TITLE
Add rotation command

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -217,6 +217,9 @@ regarding display of the region in the later function.")
 (defvar-local pdf-view--hotspot-functions nil
   "Alist of hotspot functions.")
 
+(defvar-local pdf-view--current-rotation nil
+  "Current rotation of the page.")
+
 (defvar-local pdf-view-register-alist nil
   "Local, dedicated register for PDF positions.")
 
@@ -281,6 +284,8 @@ regarding display of the region in the later function.")
     (define-key map (kbd "s m")       'pdf-view-set-slice-using-mouse)
     (define-key map (kbd "s b")       'pdf-view-set-slice-from-bounding-box)
     (define-key map (kbd "s r")       'pdf-view-reset-slice)
+    ;; Rotation.
+    (define-key map "R"              #'pdf-view-rotate)
     ;; Reconvert
     (define-key map (kbd "C-c C-c")   'doc-view-mode)
     (define-key map (kbd "g")         'revert-buffer)
@@ -583,6 +588,21 @@ For example, (pdf-view-shrink 1.25) decreases size by 20%."
   (setq pdf-view-display-size 1.0)
   (pdf-view-redisplay t))
 
+
+;; * ================================================================== *
+;; * Rotation
+;; * ================================================================== *
+(defun pdf-view-rotate (angle)
+  "Rotate the current page by ANGLE degrees clockwise.
+When called interactively, angle defaults to 90.  Moreover, if
+called interactively with a prefix argument, then rotate
+anti-clockwise."
+  (interactive (list (if current-prefix-arg -90 90)))
+  (setq-local pdf-view--current-rotation
+              (mod (+ (or pdf-view--current-rotation 0)
+                      angle)
+                   360))
+  (pdf-view-redisplay t))
 
 
 ;; * ================================================================== *
@@ -971,6 +991,7 @@ See also `pdf-view-use-imagemagick'."
                     window page size)))
     (pdf-view-create-image data
       :width (car size)
+      :rotation (or pdf-view--current-rotation 0)
       :map hotspots
       :pointer 'arrow)))
 


### PR DESCRIPTION
We need a dedicated command for rotation since when pdf-tools redisplays the image, the :rotation image-property is lost.  Pdf-tools redisplays the images when changing pages, zooming in/out, setting the slice, etc. so this is essential to have.
A variable is used simply because pdf-tools already uses a variable to keep track of the current scaling.  Fixes #152.

* lisp/pdf-view.el (pdf-view--current-rotation): Add new variable to keep track of angle.
(pdf-view-create-page): Account for above.
(pdf-view-mode-map): Add the new command under "R".
(pdf-view-rotate): Add new command.