### PR TITLE
Add `recolor-hue` option to preserve hue when recoloring the PDF

### DIFF
--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -568,7 +568,7 @@ interrupted."
          (let ((key (intern (car key-value)))
                (value (cadr key-value)))
            (cl-case key
-             ((:render/printed :render/usecolors)
+             ((:render/printed :render/usecolors :render/recolor-hue)
               (setq value (equal value "1"))))
            (push value options)
            (push key options)))
@@ -1716,7 +1716,7 @@ Returns a list \(LEFT TOP RIGHT BOT\)."
             ((:render/foreground :render/background)
              (push (pdf-util-hexcolor value)
                    soptions))
-            ((:render/usecolors :render/printed)
+            ((:render/usecolors :render/recolor-hue :render/printed)
              (push (if value 1 0) soptions))
             (t (push value soptions)))
           (push key soptions)))

--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -138,7 +138,13 @@
                         (pdf-view-midnight-minor-mode 'toggle))
       :style toggle
       :selected pdf-view-midnight-minor-mode
-      :help "Apply a color-filter appropriate for past midnight reading."])
+      :help "Apply a color-filter appropriate for past midnight reading."]
+     ["Preserve Hue Mode" (lambda ()
+                            (interactive)
+                            (pdf-view-recolor-hue-minor-mode 'toggle))
+      :style toggle
+      :selected pdf-view-recolor-hue-minor-mode
+      :help "Preserve hue when recoloring the PDF."])
     "--"
     ["Copy region" pdf-view-kill-ring-save
      :keys "\\[kill-ring-save]"

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -301,6 +301,7 @@ regarding display of the region in the later function.")
     (define-key map (kbd "C-c C-r m") 'pdf-view-midnight-minor-mode)
     (define-key map (kbd "C-c C-r t") 'pdf-view-themed-minor-mode)
     (define-key map (kbd "C-c C-r p") 'pdf-view-printer-minor-mode)
+    (define-key map (kbd "C-c C-r h") 'pdf-view-recolor-hue-minor-mode)
     map)
   "Keymap used by `pdf-view-mode' when displaying a doc as a set of images.")
 
@@ -1229,6 +1230,24 @@ The colors are determined by the variable
       (remove-hook 'after-save-hook enable t)
       (remove-hook 'after-revert-hook enable t)
       (pdf-info-setoptions :render/usecolors nil))))
+  (pdf-cache-clear-images)
+  (pdf-view-redisplay t))
+
+(define-minor-mode pdf-view-recolor-hue-minor-mode
+  "Preserve hue when recoloring the PDF (e.g. with `pdf-view-midnight-minor-mode')."
+  :group 'pdf-view
+  :lighter " Hue"
+  (pdf-util-assert-pdf-buffer)
+  (let ((enable (lambda () (pdf-info-setoptions :render/recolor-hue t))))
+    (cond
+     (pdf-view-recolor-hue-minor-mode
+      (add-hook 'after-save-hook enable nil t)
+      (add-hook 'after-revert-hook enable nil t)
+      (funcall enable))
+     (t
+      (remove-hook 'after-save-hook enable t)
+      (remove-hook 'after-revert-hook enable t)
+      (pdf-info-setoptions :render/recolor-hue nil))))
   (pdf-cache-clear-images)
   (pdf-view-redisplay t))
 

--- a/server/epdfinfo.h
+++ b/server/epdfinfo.h
@@ -187,6 +187,7 @@ typedef struct
 {
   PopplerColor bg, fg;
   gboolean usecolors;
+  gboolean recolor_hue;
   gboolean printed;
 } render_options_t;
 


### PR DESCRIPTION
This uses the algorithm from [zathura/render.c](https://github.com/pwmt/zathura/blob/4becd17ebcc0f417087c7db78d336205c9123ff4/zathura/render.c#L793) to preserve hue when recoloring the PDF.
How it looks can be seen in https://github.com/politza/pdf-tools/issues/608 for example.

I realized after implementing this that #69 achieves pretty much the same as this PR, so feel free to choose that one if it is preferred. The main difference (apart from the algorithm) is that this PR uses a minor mode (`pdf-view-recolor-hue-minor-mode`) to toggle the new `:render/recolor-hue` epdfinfo option.