### PR TITLE
Ask for a file name on save if buffer provides none

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -461,7 +461,10 @@ operating on a local copy of a remote file."
             ;; in the process), it may be immediately reopened due to
             ;; redisplay happening inside the pdf-info-close function
             ;; (while waiting for a response from the process.).
-            (copy-file tempfile (buffer-file-name) t)
+            (copy-file tempfile (or (buffer-file-name)
+                                    (read-file-name
+                                     "File name to save PDF to: "))
+                       t)
             (pdf-info-close pdf-view--server-file-name)
 
             (when pdf-view--buffer-file-name


### PR DESCRIPTION
When visiting a pdf file downloaded by eww, buffer-file-name returns nil so the file can't be saved.  I think it's OK to always ask user for a file name if buffer doesn't have it.