### PR TITLE
quiet the byte compiler

### DIFF
--- a/lisp/pdf-cache.el
+++ b/lisp/pdf-cache.el
@@ -27,6 +27,11 @@
 (require 'pdf-info)
 (require 'pdf-util)
 
+(eval-when-compile
+  (declare-function pdf-view-desired-image-size "pdf-view")
+  (declare-function pdf-view-create-page "pdf-view")
+  (declare-function image-mode-window-get "image-mode"))
+
 
 ;; * ================================================================== *
 ;; * Customiazations

--- a/lisp/pdf-dev.el
+++ b/lisp/pdf-dev.el
@@ -25,6 +25,12 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (defvar pdf-info-epdfinfo-program)
+  (defvar pdf-info-restart-process-p)
+  (declare-function pdf-info-process-assert-running "pdf-info")
+  (declare-function pdf-info-quit "pdf-info"))
+
 (defvar pdf-dev-root-directory
   (file-name-directory
    (directory-file-name

--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -51,6 +51,12 @@
 (require 'tq)
 (require 'cl-lib)
 
+(eval-when-compile
+  (declare pdf-util-frame-scale-factor "pdf-util")
+  (declare pdf-util-hexcolor "pdf-util")
+  (declare pdf-util-munch-file "pdf-util")
+  (declare pdf-util-highlight-regexp-in-string "pdf-util")
+  (declare pdf-view-buffer-file-name "pdf-view"))
 
 
 ;; * ================================================================== *

--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -32,10 +32,14 @@
 
 ;; These functions are only used after a PdfView window was asserted,
 ;; which won't succeed, if pdf-view.el isn't loaded.
-(declare-function pdf-view-image-size "pdf-view")
-(declare-function pdf-view-image-offset "pdf-view")
-(declare-function pdf-cache-pagesize "pdf-cache")
-(declare-function pdf-view-image-type "pdf-view")
+(eval-when-compile
+  (declare-function pdf-view-image-size "pdf-view")
+  (declare-function pdf-view-image-offset "pdf-view")
+  (declare-function pdf-cache-pagesize "pdf-cache")
+  (declare-function pdf-view-image-type "pdf-view")
+  (declare-function image-set-window-hscroll "image-mode")
+  (declare-function image-set-window-vscroll "image-mode")
+  (declare-function image-mode-window-get "image-mode"))
 
 
 

--- a/lisp/pdf-virtual.el
+++ b/lisp/pdf-virtual.el
@@ -35,7 +35,13 @@
 (require 'pdf-info)
 (require 'pdf-util)
 
-(declare-function pdf-view-mode "pdf-view.el")
+;; quiet byte-compiler warning
+(eval-when-compile
+  (defvar pdf-view-mode-map)
+  (declare-function pdf-view-goto-page "pdf-view.el")
+  (declare-function image-mode-window-get "image-mode.el")
+  (declare-function pdf-view-mode "pdf-view.el"))
+
 
 ;; * ================================================================== *
 ;; * Variables


### PR DESCRIPTION
just defvar and declare-functions to suppress elisp byte compiler warnings

Those changes are just code cosmetics and doesn't influence functionality.

I'm a bit unsure about the correct use of `eval-when-compile` here, but those changes work for me. This PR is just to satisfy the byte compiler with recent version of pdf-tools.