### PR TITLE
Add command and submenu to switch between selection styles

### DIFF
--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -143,6 +143,19 @@
     ["Copy region" pdf-view-kill-ring-save
      :keys "\\[kill-ring-save]"
      :active (pdf-view-active-region-p)]
+    ("Selection style"
+     ["Glyph" (pdf-view-set-selection-style 'glyph)
+      :style radio
+      :selected (eq pdf-view-selection-style 'glyph)
+      :help "When dragging the mouse, select individual characters."]
+     ["Word" (pdf-view-set-selection-style 'word)
+      :style radio
+      :selected (eq pdf-view-selection-style 'word)
+      :help "When dragging the mouse, select entire words."]
+     ["Line" (pdf-view-set-selection-style 'line)
+      :style radio
+      :selected (eq pdf-view-selection-style 'line)
+      :help "When dragging the mouse, select entire lines."])
     "--"
     ["Isearch document" isearch-forward
      :visible (bound-and-true-p pdf-isearch-minor-mode)]

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -1622,6 +1622,20 @@ the `convert' program is used."
       (dolist (f (cons result images))
         (when (file-exists-p f)
           (delete-file f))))))
+
+(defun pdf-view-set-selection-style (&optional style)
+  "Set the value of `pdf-view-selection-style' in the current buffer.
+
+When called interactively or without an argument, cycle between
+the selection styles."
+  (interactive)
+  (unless style
+    (setq style (or (cadr (memq pdf-view-selection-style '(glyph word line)))
+                    'glyph))
+    (message "Setting selection style to `%s'." style))
+  (pdf-view-deactivate-region)
+  (setq-local pdf-view-selection-style style))
+
 
 ;; * ================================================================== *
 ;; * Bookmark + Register Integration


### PR DESCRIPTION
It might also make sense to find a keybinding to this new command, but I would leave that up to you to choose.

Incidentally, I wish it was possible to momentarily switch to a different selection style, say while holding shift, say with this command:

```
(defun pdf-view-finegrained-mouse-set-region ()
  (interactive)
  (let ((pdf-view-selection-style 'glyph)))
    (call-interactively #'pdf-view-mouse-set-region)))
```

But this doesn't work because `pdf-view-active-region` stores the area physically traced by the mouse, and the conversion so characters/words/lines is done only when using the region (e.g. to add an annotation).

I think it would make sense to store the selection style used for each selection, in the same vein of `pdf-view--have-rectangle-region`.