### PR TITLE
Allow creation of markup annotations without a text selection

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1053,9 +1053,12 @@ Return the new annotation."
              (> (length edges) 1))
     (error "Edges argument should be a single edge-list for text annotations"))
   (let* ((selection-style pdf-view-selection-style)
+         (non-markup (pcase type
+                       ('text t)
+                       ('highlight pdf-view--have-rectangle-region)))
          (a (apply #'pdf-info-addannot
                    page
-                   (if (eq type 'text)
+                   (if non-markup
                        (car edges)
                      (apply #'pdf-util-edges-union
                             (apply #'append
@@ -1066,7 +1069,7 @@ Return the new annotation."
                    type
                    selection-style
                    nil
-                   (if (not (eq type 'text)) edges)))
+                   (unless non-markup edges)))
          (id (pdf-annot-get-id a)))
     (when property-alist
       (condition-case err

--- a/server/epdfinfo.c
+++ b/server/epdfinfo.c
@@ -1607,6 +1607,21 @@ annotation_new (const epdfinfo_t *ctx, document_t *doc, PopplerPage *page,
 #ifdef HAVE_POPPLER_ANNOT_MARKUP
   garray = g_array_new (FALSE, FALSE, sizeof (PopplerQuadrilateral));
   poppler_page_get_size (page, &width, &height);
+  if (nargs == 0)
+    {
+      PopplerQuadrilateral q;
+
+      q.p1.x = r->x1;
+      q.p1.y = r->y1;
+      q.p2.x = r->x2;
+      q.p2.y = r->y1;
+      q.p4.x = r->x2;
+      q.p4.y = r->y2;
+      q.p3.x = r->x1;
+      q.p3.y = r->y2;
+
+      g_array_append_val (garray, q);
+    }
   for (i = 0; i < nargs; ++i)
     {
       PopplerRectangle *rr = &carg.value.rectangle;


### PR DESCRIPTION
I would like to be able to annotate an arbitrary region of the page after selecting it with `M-drag-mouse`. For instance, the following selection:

![image](https://user-images.githubusercontent.com/6500902/218270529-db8ab0a8-8cc3-4f98-b903-68123e9b5bf9.png)

produces this annotation

![image](https://user-images.githubusercontent.com/6500902/218270634-21d30af5-c435-40a1-9ffe-c7912bc3c7b3.png)

I would rather be able to do this:

![image](https://user-images.githubusercontent.com/6500902/218270544-2592b036-5ddb-481c-9d60-9b0b151b12e3.png)

Perhaps this would be better achieved with a "Square" annotation, which epdfinfo doesn't support (although apparently poppler does). Lacking that, however, a highlight annotation seem suitable.

EDIT: In the updated version of this PR, the red annotation can created by calling `pdf-annot-add-highlight-markup-annotation` when the region is a rectangle (if multiple rectangles are selected, only the first is used). We could add a customization option to preserve the original behavior, but I think I would rather wait and see if anyone complains.

Do you think this is a good approach, given that adding the other annotation types would be a much bigger effort?