### PR TITLE
Display a header line when editing annotation contents

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1447,6 +1447,7 @@ annotation's contents and otherwise `org-mode'."
     (set-keymap-parent kmap text-mode-map)
     (define-key kmap (kbd "C-c C-c") #'pdf-annot-edit-contents-commit)
     (define-key kmap (kbd "C-c C-q") #'pdf-annot-edit-contents-abort)
+    (define-key kmap (kbd "C-c C-k") #'pdf-annot-edit-contents-abort)
     kmap))
 
 (define-minor-mode pdf-annot-edit-contents-minor-mode

--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1453,9 +1453,9 @@ annotation's contents and otherwise `org-mode'."
   "Active when editing the contents of annotations."
   :group 'pdf-annot
   (when pdf-annot-edit-contents-minor-mode
-    (message "%s"
-             (substitute-command-keys
-              "Press \\[pdf-annot-edit-contents-commit] to commit your changes, \\[pdf-annot-edit-contents-abort] to abandon them."))))
+    (setq-local header-line-format
+                (substitute-command-keys "\
+Press \\[pdf-annot-edit-contents-commit] to commit your changes, \\[pdf-annot-edit-contents-abort] to abandon them."))))
 
 (put 'pdf-annot-edit-contents-minor-mode 'permanent-local t)
 
@@ -1510,11 +1510,8 @@ At any given point of time, only one annotation can be in edit mode."
         (pdf-annot-edit-contents-finalize 'ask)))
     (unless (buffer-live-p pdf-annot-edit-contents--buffer)
       (setq pdf-annot-edit-contents--buffer
-            (with-current-buffer (get-buffer-create
-                                  (format "*Edit Annotation %s*"
-                                          (buffer-name)))
-              (pdf-annot-edit-contents-minor-mode 1)
-              (current-buffer))))
+            (get-buffer-create
+             (format "*Edit Annotation %s*" (buffer-name)))))
     (with-current-buffer pdf-annot-edit-contents--buffer
       (let ((inhibit-read-only t))
         (erase-buffer)
@@ -1522,6 +1519,7 @@ At any given point of time, only one annotation can be in edit mode."
         (set-buffer-modified-p nil))
       (setq pdf-annot-edit-contents--annotation a)
       (funcall pdf-annot-edit-contents-setup-function a)
+      (pdf-annot-edit-contents-minor-mode 1)
       (current-buffer))))
 
 (defun pdf-annot-edit-contents (a)


### PR DESCRIPTION
Instead of using an echo area message that disappears, display the keys to commit and abort in the header line. This is similar to what org-capture does.

I could also add a customization option to keep the old behavior (but note that a more advanced user can do this anyway using `pdf-annot-edit-contents-minor-mode-hook`).

Finally, a tangential comment: For consistency with org-capture and magit's commit message editor, `pdf-annot-edit-contents-abort` should be `C-c C-k` instead of `C-c C-q`. Should we add an additional binding in the minor mode map?