### PR TITLE
pdf-view-mode: remove default space before "P" in mode line

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -347,7 +347,7 @@ PNG images in Emacs buffers."
 
   ;; Setup other local variables.
   (setq-local mode-line-position
-              '(" P" (:eval (number-to-string (pdf-view-current-page)))
+              '("P" (:eval (number-to-string (pdf-view-current-page)))
                 ;; Avoid errors during redisplay.
                 "/" (:eval (or (ignore-errors
                                  (number-to-string (pdf-cache-number-of-pages)))


### PR DESCRIPTION
I recently altered my mode line to be a bit more minimal. I set the default value of `mode-line-position` to `("%C/%l")`, and then include `(:propertize ("[" mode-line-position "]") face italic)` in my mode line. Pdf view's mode line integration is great, but screws this up slightly because it assumes that the user wants an extra space before the "P" page indicator (which I don't -- I want it look just like the column/line indicator usually does).

This PR fixes this. Users who still want the extra space can add it manually in their mode line configuration (though conversely, there is no obvious way for users like me to *remove* it if it is there by default).