### PR TITLE
Add `cairo-devel` to Void Linux package list

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -434,7 +434,8 @@ os_void() {
               poppler-glib-devel
               zlib-devel
               make
-              pkgconf"
+              pkgconf
+              cairo-devel"
     PKGCMD=xbps-install
     PKGARGS="-Sy"
     export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/lib/pkgconfig"


### PR DESCRIPTION
In Void Linux most headers/development files are separated from the "main" packages and are stored on `${package-name}-devel`. The autobuild for Void fails because it tries to find `cairo-devel`, which contains `cairo`, respectives headers and other dependencies.

This Pull Request adds `cairo-devel` to the `PACKAGES` variable