### PR TITLE
Ensure pixel-scroll-precision-mode deactivation

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -365,6 +365,8 @@ PNG images in Emacs buffers."
   ;; Disable pixel-scroll-precision-mode locally if enabled
   (if (bound-and-true-p pixel-scroll-precision-mode)
       (set (make-local-variable 'pixel-scroll-precision-mode) nil))
+  (if (boundp 'mwheel-coalesce-scroll-events)
+      (setq-local mwheel-coalesce-scroll-events t))
 
   ;; Clearing overlays
   (add-hook 'change-major-mode-hook


### PR DESCRIPTION
Setting `pixel-scroll-precision-mode` to nil is not sufficient to disable the mode locally.

Updates: #124
