### PR TITLE
keep cursor on the same line when reopening list of annotations

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1720,16 +1720,18 @@ pretty-printed output."
 \\{pdf-annot-list-mode-map}"
   (interactive)
   (pdf-util-assert-pdf-buffer)
-  (let ((buffer (current-buffer)))
-    (with-current-buffer (get-buffer-create
-                          (format "*%s's annots*"
-                                  (file-name-sans-extension
-                                   (buffer-name))))
+  (let* ((buffer (current-buffer))
+         (name (format "*%s's annots*"
+                       (file-name-sans-extension
+                        (buffer-name))))
+         (annots-existed (get-buffer name)))
+    (with-current-buffer (get-buffer-create name)
       (delay-mode-hooks
         (unless (derived-mode-p 'pdf-annot-list-mode)
           (pdf-annot-list-mode))
         (setq pdf-annot-list-document-buffer buffer)
-        (tabulated-list-print)
+        (unless annots-existed
+          (tabulated-list-print))
         (setq tablist-context-window-function
               (lambda (id) (pdf-annot-list-context-function id buffer))
               tablist-operations-function #'pdf-annot-list-operation-function)

--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1724,7 +1724,8 @@ pretty-printed output."
          (name (format "*%s's annots*"
                        (file-name-sans-extension
                         (buffer-name))))
-         (annots-existed (get-buffer name)))
+         (annots-existed (and (get-buffer name)
+                              pdf-annot-list-buffer)))
     (with-current-buffer (get-buffer-create name)
       (delay-mode-hooks
         (unless (derived-mode-p 'pdf-annot-list-mode)


### PR DESCRIPTION
Simply check whether the buffer of the list of annotations already exists.  In that case, avoid calling `tabulated-list-print` because the call to that function makes the cursor move to the beginning of the buffer.  Tested for the case in which the buffer of the list of annotations already exists; a new note is created; that buffer is reopened with the cursor on the same position as previous left; and the newly inserted note appears as expected.  Not sure if further tests should be done or the implication of avoiding calling `tabulated-list-print` every time.