### PR TITLE
[pdf-sync] use absolute line number to work in narrowed buffer

### DIFF
--- a/lisp/pdf-sync.el
+++ b/lisp/pdf-sync.el
@@ -670,7 +670,7 @@ Returns a list \(PDF PAGE X1 Y1 X2 Y2\), where PAGE, X1, Y1, X2
 and Y2 may be nil, if the destination could not be found."
   (unless (fboundp 'TeX-master-file)
     (error "This function works only with AUCTeX"))
-  (unless line (setq line (line-number-at-pos)))
+  (unless line (setq line (line-number-at-pos nil t)))
   (unless column (setq column (current-column)))
 
   (let* ((pdf (expand-file-name


### PR DESCRIPTION
`line-number-at-pos` should be called with second argument `absolute` set to `t` in order for `pdf-sync-forward-correlate` to work in buffers with active narrowing.