### PR TITLE
Fix links display when pdf-view-use-scaling is t

### DIFF
--- a/lisp/pdf-links.el
+++ b/lisp/pdf-links.el
@@ -248,10 +248,14 @@ See `pdf-links-action-perform' for the interface."
                  `((?c . ,(lambda (_edges) (pop key-strings)))
                    (?P . ,(number-to-string
                            (max 1 (* (cdr size)
+                                     (pdf-util-frame-scale-factor)
                                      pdf-links-convert-pointsize-scale)))))
                  :commands pdf-links-read-link-convert-commands
                  :apply (pdf-util-scale-relative-to-pixel
-                         (mapcar (lambda (l) (cdr (assq 'edges l)))
+                         (mapcar (lambda (l)
+                                   (mapcar (lambda (x)
+                                             (* x (pdf-util-frame-scale-factor)))
+                                           (cdr (assq 'edges l))))
                                  links)))))
     (unless links
       (error "No links on this page"))
@@ -266,7 +270,7 @@ See `pdf-links-action-perform' for the interface."
              (pdf-view-current-page)
              (car size) image-data 'pdf-links-read-link-action))
           (pdf-view-display-image
-           (create-image image-data (pdf-view-image-type) t))
+           (pdf-view-create-image image-data))
           (pdf-links-read-link-action--read-chars prompt alist))
       (pdf-view-redisplay))))
 


### PR DESCRIPTION
I encounter the issue when opening links when `pdf-view-use-scaling` is `t`.

The reason is that we use `create-image` instead of `pdf-view-create-image`; so the image size is incorrect.

Besides, we also need to fix the link location.

Please take a look at the PR.

At least it works on my machine.

OS: macOS 10.15.7 Catalina
Emacs: 28.2
