### PR TITLE
Add support for Android Emacs using Termux

### DIFF
--- a/lisp/pdf-tools.el
+++ b/lisp/pdf-tools.el
@@ -321,7 +321,7 @@ Returns the buffer of the compilation process."
          (process-environment process-environment)
          (default-directory build-directory)
          (autobuild (shell-quote-argument
-                     (expand-file-name "autobuild" build-directory)))
+                     (expand-file-name (if (eq system-type 'android) "autobuild.android" "autobuild") build-directory)))
          (msys2-p (equal "bash.exe" (file-name-nondirectory shell-file-name))))
     (unless shell-file-name
       (error "No suitable shell found"))

--- a/server/autobuild
+++ b/server/autobuild
@@ -306,6 +306,26 @@ os_debian() {
     return 0
 }
 
+# Android using Termux
+os_android() {
+    if ! [ -d "/data/data/com.termux/files/home" ]; then
+        return 1
+    fi
+    PACKAGES="autoconf
+              automake
+	            binutils
+              clang
+              libpng
+              poppler
+              zlib
+              make
+	            xorgproto
+              pkg-config"
+    PKGCMD=pkg
+    PKGARGS="install"
+    return 0
+}
+
 # Msys2
 os_msys2() {
     if [ -z "$MSYSTEM" ] || ! [ -r "/etc/profile" ]; then
@@ -508,6 +528,7 @@ os_argument() {
         void)    os_void    "$@";;
         opensuse) os_opensuse "$@";;
         alpine)  os_alpine  "$@";;
+        android) os_android  "$@";;
         *)       echo "Invalid --os argument: $OS"
                  exit 1
     esac || {
@@ -538,6 +559,7 @@ os_nixos    "$@" || \
 os_void     "$@" || \
 os_opensuse "$@" || \
 os_alpine   "$@" || \
+os_android  "$@" || \
 {
     OS_IS_HANDLED=
     if [ -z "$DRY_RUN" ]; then

--- a/server/autobuild.android
+++ b/server/autobuild.android
@@ -1,0 +1,2 @@
+#!/bin/sh
+sh autobuild $@


### PR DESCRIPTION
Add support for pdf-tools-install in Android Emacs using Termux.
The dependencies for android in autobuild can not be installed in pdf-tools-install, they have to be installed manually in Termux. But the dependencies are checked when running autobuild.

pdf-tools-install successfully installs epdfinfo in Android Emacs. One can then view pdf files.

The shebang in autobuild does not work in Termux, I therefore had to create a separate script "autobuild.android" that in turn executes autobuild. The problem with the shebang is that "env" in Termux is not located at "/usr/bin/env". 

pdf-tools/Makefile does currently not work in Android Emacs, but it is not needed for running pdf-tools-install. Fixing this will have to be done in a separate pull request, if deemed necessary. Reason: There is yet no consensus for how to implement a command line emacs, to be run in batch mode, in Android Emacs.

I have successfully run "make test" in Ubuntu, in the repo feature branch.
Running "make server-test" in the master branch fails, so I have not tested this in the feature branch.