### PR TITLE
fix: scroll by arg lines

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -812,7 +812,7 @@ at the bottom edge of the page moves to the next page."
             (image-bob)
             (image-bol 1))
           (image-set-window-hscroll hscroll)))
-    (image-next-line 1)))
+    (image-next-line arg)))
 
 (defun pdf-view-previous-line-or-previous-page (&optional arg)
   "Scroll downward by ARG lines if possible, else go to the previous page.


### PR DESCRIPTION
scroll by `arg` lines instead of just 1