### PR TITLE
Fixing #246: "epdfinfo: No such annotation: annot-X-Y"

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -1512,6 +1512,7 @@ At any given point of time, only one annotation can be in edit mode."
                (not (eq a pdf-annot-edit-contents--annotation)))
       (with-current-buffer pdf-annot-edit-contents--buffer
         (pdf-annot-edit-contents-finalize 'ask)))
+    (pdf-annot-getannots (pdf-view-current-page)) ; avoids "epdfinfo: No such annotation: annot-N-M"
     (unless (buffer-live-p pdf-annot-edit-contents--buffer)
       (setq pdf-annot-edit-contents--buffer
             (get-buffer-create


### PR DESCRIPTION
Somehow the annotations in buffer and file are out-of-sync, which is fixed by refreshing the annotations on the current page.