### PR TITLE
Some pdf decryption improvements

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -466,12 +466,14 @@ PNG images in Emacs buffers."
   "Read a password, if the document is encrypted and open it."
   (interactive)
   (when (pdf-info-encrypted-p)
-    (let ((prompt (format "Enter password for `%s': "
-                          (abbreviate-file-name
-                           (buffer-file-name))))
-          (key (concat "/pdf-tools" (buffer-file-name)))
+    (let ((fn (buffer-file-name))
+          (prompt "Enter password for pdf document: ")
           (i 3)
-          password)
+          key password)
+      (when fn
+        (setq prompt (format "Enter password for `%s': "
+                             (abbreviate-file-name fn)))
+        (setq key (concat "/pdf-tools" fn)))
       (while (and (> i 0)
                   (pdf-info-encrypted-p))
         (setq i (1- i))
@@ -479,7 +481,8 @@ PNG images in Emacs buffers."
         (setq prompt "Invalid password, try again: ")
         (ignore-errors (pdf-info-open nil password)))
       (pdf-info-open nil password)
-      (password-cache-add key password)))
+      (when key
+        (password-cache-add key password))))
   nil)
 
 (defun pdf-view-buffer-file-name ()

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -553,6 +553,7 @@ Optional parameters IGNORE-AUTO and NOCONFIRM are defined as in
                after-revert-hook)))
     (prog1
         (revert-buffer ignore-auto noconfirm 'preserve-modes)
+      (pdf-view-decrypt-document)
       (pdf-view-redisplay t))))
 
 (defun pdf-view-close-document ()


### PR DESCRIPTION
- Support decryption of non-file-visiting pdf buffers, for example, when opening a pdf e-mail attachment from within Emacs
- Don't retry with the same cached password upon decryption failure, to support re-opening a pdf file with a modified password
- Don't error during 'revert-buffer' on encrypted documents