### PR TITLE
Fix pdf-loader-install calling pdf-tools-install with wrong args

### DIFF
--- a/lisp/pdf-loader.el
+++ b/lisp/pdf-loader.el
@@ -57,7 +57,7 @@ see."
 (defun pdf-loader--load (&rest args)
   (pdf-loader--uninstall)
   (save-selected-window
-    (pdf-tools-install args)))
+    (apply #'pdf-tools-install args)))
 
 (defun pdf-loader--install (loader)
   (pdf-loader--uninstall)


### PR DESCRIPTION
I noticed that `pdf-loader-install` was causing epdfinfo to be
compiled immediately upon loading a pdf file, whereas
`pdf-tools-install` prompts the user before doing that, if called with
no arguments.

This PR fixes the inconsistency by passing the arguments correctly.