### PR TITLE
Fix defcustom :type arguments

### DIFF
--- a/lisp/pdf-tools.el
+++ b/lisp/pdf-tools.el
@@ -212,11 +212,13 @@ PDF buffers."
 (defcustom pdf-tools-installer-os nil
   "Specifies which installer to use.
 
-If nil the installer is chosen automatically. This variable is
+If nil, the installer is chosen automatically.  This variable is
 useful if you have multiple installers present on your
 system (e.g. nix on arch linux)"
   :group 'pdf-tools
-  :type 'string)
+  :type '(choice
+          (const :tag "Choose automatically" nil)
+          string))
 
 (defun pdf-tools-identify-build-directory (directory)
   "Return non-nil, if DIRECTORY appears to contain the epdfinfo source.

--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -907,21 +907,23 @@ frame's PPI is larger than 180. Otherwise, return 1."
     (executable-find "convert"))
   "Absolute path to the convert program."
   :group 'pdf-tools
-  :type 'executable)
+  :type '(choice (const :tag "Unset" nil) file))
 
 (defcustom pdf-util-fast-image-format nil
   "An image format appropriate for fast displaying.
 
-This should be a cons \(TYPE . EXT\) where type is the Emacs
-image-type and EXT the appropriate file extension starting with a
-dot. If nil, the value is determined automatically.
+This should be a cons (TYPE . EXT) where type is the Emacs
+`image-type' and EXT the appropriate file extension starting with
+a dot.  If nil, the value is determined automatically.
 
 Different formats have different properties, with respect to
 Emacs loading time, convert creation time and the file-size.  In
 general, uncompressed formats are faster, but may need a fair
 amount of (temporary) disk space."
   :group 'pdf-tools
-  :type '(cons symbol string))
+  :type '(choice
+          (const :tag "Determine automatically" nil)
+          (cons symbol string)))
 
 (defun pdf-util-assert-convert-program ()
   (unless (and pdf-util-convert-program


### PR DESCRIPTION
These variables' default values should match the :type given in their
definitions, or else M-x customize will display a warning or may even
fail to initialize properly.