### PR TITLE
Fix MinGW build failure due to vasprintf

### DIFF
--- a/server/synctex_parser.c
+++ b/server/synctex_parser.c
@@ -8415,7 +8415,7 @@ static int _synctex_updater_print(synctex_updater_p updater, const char * format
     }
     return result;
 }
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>


### PR DESCRIPTION
MinGW’s compiler (GCC 14.2.0) errors out compiling `synctex_parser.c`.

```
synctex_parser.c: In function '_synctex_updater_print_gz':
synctex_parser.c:8448:13: error: implicit declaration of function
'vasprintf'; did you mean 'vsprintf'?
  8448 |     if (vasprintf(&buffer, format, va) < 0) {
    |       ^~~~~~~~~
    |       vsprintf
```

`vasprintf` is a custom function (not the standard `vsprintf`) that’s defined in the same translation unit a few lines above.

However its definition is wrapped within a `if defined(_MSC_VER)` i.e. it’s only enabled when compiled with MSVC compiler.  This fix enables it also for MinGW compilers.

Fixes #286.