### PR TITLE
Add support for Nobara Linux

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -493,6 +493,30 @@ os_alpine() {
     return 0
 }
 
+# Nobara
+os_nobara() {
+    if ! [ -e "/etc/nobara-release" ]; then
+        return 1
+    fi
+    PKGCMD=dnf
+    PKGARGS=install
+    PACKAGES="autoconf
+              automake
+              gcc
+              libpng-devel
+              make
+              poppler-devel
+              poppler-glib-devel
+              zlib-devel"
+    VERSION=$(source_var /etc/os-release VERSION_ID)
+    if [ -n "$VERSION" ] && [ "$VERSION" -ge 26 ]; then
+        PACKAGES="$PACKAGES pkgconf"
+    else
+        PACKAGES="$PACKAGES pkgconfig"
+    fi
+    return 0
+}
+
 # By Parameter --os
 os_argument() {
     [ -z "$OS" ] && return 1
@@ -511,6 +535,7 @@ os_argument() {
         void)    os_void    "$@";;
         opensuse) os_opensuse "$@";;
         alpine)  os_alpine  "$@";;
+        nobara)  os_nobara  "$@";;
         *)       echo "Invalid --os argument: $OS"
                  exit 1
     esac || {
@@ -541,6 +566,7 @@ os_nixos    "$@" || \
 os_void     "$@" || \
 os_opensuse "$@" || \
 os_alpine   "$@" || \
+os_nobara   "$@" || \
 {
     OS_IS_HANDLED=
     if [ -z "$DRY_RUN" ]; then


### PR DESCRIPTION
### [Nobara Linux](https://nobaraproject.org)
> The Nobara Project, to put it simply, is a modified version of Fedora Linux with user-friendly fixes added to it.

Since it's a Fedora derivative, I just had to take the  Fedora configuration that was already there and rename it to Nobara instead. This commit can be simplified if there's some kind of way to "alias" Nobara to Fedora but I don't know how I'd go about this way.