### PR TITLE
In interactive calls, suppress out-of-bound errors

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -695,8 +695,10 @@ windows."
 
 Optional parameter N moves N pages forward."
   (interactive "p")
-  (pdf-view-goto-page (+ (pdf-view-current-page)
-                         (or n 1))))
+  (condition-case nil
+      (pdf-view-goto-page (+ (pdf-view-current-page)
+                             (or n 1)))
+    (error nil)))
 
 (defun pdf-view-previous-page (&optional n)
   "View the previous page in the PDF.


### PR DESCRIPTION
When viewing a PDF, calling `pdf-view-next-page` or `pdf-view-previous-page` throws an error if those commands are called at the end or beginning of a document, respectively. I think this behavior is not desired: it is very common to invoke these commands repeatedly to navigate to the beginning or end of a document, and it is mildly annoying to see a backtrace pop up (when `debug-on-error` is enabled) just because one invoked the command one more time than strictly necessary. This PR suppresses the error message in these cases.