### PR TITLE
Support MSYS2 UCRT64 environment

### DIFF
--- a/server/autobuild
+++ b/server/autobuild
@@ -332,6 +332,16 @@ os_msys2() {
                       mingw-w64-i686-toolchain
                       mingw-w64-i686-openssl
                       mingw-w64-i686-zlib" ;;
+        UCRT64)
+            PACKAGES="base-devel
+                      autoconf
+                      automake
+                      mingw-w64-ucrt-x86_64-libpng
+                      mingw-w64-ucrt-x86_64-poppler
+                      mingw-w64-ucrt-x86_64-imagemagick
+                      mingw-w64-ucrt-x86_64-toolchain
+                      mingw-w64-ucrt-x86_64-openssl
+                      mingw-w64-ucrt-x86_64-zlib" ;;
         MSYS)
             case $(uname -m) in
                 x86_64)

--- a/server/configure.ac
+++ b/server/configure.ac
@@ -36,7 +36,7 @@ AC_COMPILE_IFELSE(
 AM_CONDITIONAL(HAVE_W32, [test "$have_w32" = true])
 
 if test "$have_w32" = true; then
-  if test "$MSYSTEM" = MINGW32 -o "$MSYSTEM" = MINGW64; then
+  if test "$MSYSTEM" = MINGW32 -o "$MSYSTEM" = MINGW64 -o "$MSYSTEM" = UCRT64; then
   # glib won't work properly on msys2 without it.
     CFLAGS="-D__USE_MINGW_ANSI_STDIO=1 $CFLAGS"
   fi

--- a/server/synctex_parser.c
+++ b/server/synctex_parser.c
@@ -8415,7 +8415,7 @@ static int _synctex_updater_print(synctex_updater_p updater, const char * format
     }
     return result;
 }
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/server/synctex_parser.c
+++ b/server/synctex_parser.c
@@ -8415,7 +8415,8 @@ static int _synctex_updater_print(synctex_updater_p updater, const char * format
     }
     return result;
 }
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_WIN32)
+// define vasprintf as it’s available only on Linux and macOS.
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -8424,17 +8425,14 @@ static int vasprintf(char **ret,
                      const char *format,
                      va_list ap)
 {
-    int len;
-    len = _vsnprintf(NULL, 0, format, ap);
+    int len = vsnprintf(NULL, 0, format, ap);
     if (len < 0) return -1;
     *ret = malloc(len + 1);
     if (!*ret) return -1;
-    _vsnprintf(*ret, len+1, format, ap);
-    (*ret)[len] = '\0';
-    return len;
+    return vsnprintf(*ret, len + 1, format, ap);
 }
 
-#endif
+#endif // _WIN32
 
 /**
  *  gzvprintf is not available until OSX 10.10


### PR DESCRIPTION
UCRT64 is the newer MSYS2 environment compared to MINGW{32,64}.  This
is the recommended default [1].

> If you are unsure, go with UCRT64.

[1]: https://www.msys2.org/docs/environments/