### PR TITLE
additional functionality for pdf-misc.el (pdffonts+)

### DIFF
--- a/lisp/pdf-misc.el
+++ b/lisp/pdf-misc.el
@@ -1,10 +1,19 @@
-;;; pdf-misc.el --- Miscellaneous commands for PDF buffer.  -*- lexical-binding: t; -*-
+;;; pdf-misc.el --- Miscellaneous commands for PDF buffer  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013, 2014  Andreas Politz
+;; Copyright (C) 2025  Benjamin Slade
 
 ;; Author: Andreas Politz <politza@fh-trier.de>
+;; Maintainer: Vedang Manerikar <vedang.manerikar@gmail.com>
+;; URL: https://github.com/vedang/pdf-tools/
+;; Package-Requires: ((emacs "24.4") (org "9.4"))
+;; Package-Version: 0.11
+;; Version: 0.11
 ;; Keywords: files, multimedia
 
+;; This file is NOT part of GNU Emacs.
+
+;;; License:
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -16,26 +25,48 @@
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+;; miscellaneous commands for PDF buffers: metadata, printing, &c.
 
+;;; Code:
 
 (require 'pdf-view)
 (require 'pdf-util)
 (require 'imenu)
+(require 'pdf-tools) ; for `pdf-tools-pdf-buffer-p'
+(require 'org)
 
 
+;;; Misc. group and defcustom definitions
 
-;;; Code:
+(defgroup pdf-misc nil
+  "Miscellaneous options for PDF documents."
+  :group 'pdf-tools)
+
+(defcustom pdf-misc-print-program-executable nil
+  "Executable for printing."
+  :group 'pdf-tools
+  :type 'string)
+
+;;; Keybindings
 
 (defvar pdf-misc-minor-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "I") 'pdf-misc-display-metadata)
-    (define-key map (kbd "C-c C-p") 'pdf-misc-print-document)
+    ;; `I' for `Info', = pdf metadata:
+    (define-key map (kbd "I") #'pdf-misc-display-metadata)
+    ;; `O' for `Org-style' Info, = pdf metadata in orgish display:
+    (define-key map (kbd "O") #'pdf-misc-display-metadata-org-style)
+    ;; `T' for `Typeface', i.e., Font info [since `F' is already taken]:
+    (define-key map (kbd "T") #'pdf-misc-display-font-information)
+    ;; `U' for `Unified' info, i.e., both Metadata and Font info:
+    (define-key map (kbd "U") #'pdf-misc-display-combined-metadata-and-font-info)
+    ;; `c'ommand to `p'rint:
+    (define-key map (kbd "C-c C-p") #'pdf-misc-print-document)
     map)
   "Keymap used in `pdf-misc-minor-mode'.")
+
 
 ;;;###autoload
 (define-minor-mode pdf-misc-minor-mode
@@ -212,6 +243,44 @@
                    (lookup-key pdf-misc-menu-bar-minor-mode-map
                                [menu-bar pdf\ tools]))))))
 
+;;; misc helper functions
+(defun pdf-misc--merge-cons-to-string (lst)
+  "Merge a list `LST' into a white-space separated string."
+  ;; start with first item to avoid leading space
+  (let ((unified-field-string (car lst))
+        (remain (cdr lst)))
+    ;; then process remainder, adding a " " between
+    (dolist (w remain)
+      (setq unified-field-string
+            (concat
+             unified-field-string
+             " "
+             w)))
+    unified-field-string))
+
+(defun pdf-misc--flatten-tree (tree)
+  "Return a \"flattened\" copy of TREE.
+In other words, return a list of the non-nil terminal nodes, or
+leaves, of the tree of cons cells rooted at TREE.  Leaves in the
+returned list are in the same order as in TREE.
+
+\(flatten-tree \\='(1 (2 . 3) nil (4 5 (6)) 7))
+=> (1 2 3 4 5 6 7).
+[Taken from subr.el to avoid requiring Emacs 27.1]"
+  (declare (side-effect-free error-free))
+  (let (elems)
+    (while (consp tree)
+      (let ((elem (pop tree)))
+        (while (consp elem)
+          (push (cdr elem) tree)
+          (setq elem (car elem)))
+        (if elem (push elem elems))))
+    (if tree (push tree elems))
+    (nreverse elems)))
+
+;;; metadata functions
+
+;;;; PDF metadata
 (defun pdf-misc-display-metadata ()
   "Display all available metadata in a separate buffer."
   (interactive)
@@ -246,6 +315,210 @@
       (display-buffer (current-buffer)))
     md))
 
+(defun pdf-misc-display-metadata-org-style (doc &optional combined)
+  "Display all available metadata in a separate buffer in Org-mode style.
+Argument `DOC' defaults to current buffer if it contains a PDF file;
+otherwise queries for a PDF file.  The optional argument `COMBINED' is
+used when combined with `pdf-misc-display-font-information'."
+  (interactive
+   (if (pdf-tools-pdf-buffer-p)
+       (list (buffer-file-name))
+     (list (read-file-name "Choose PDF file:"))))
+  (let ((raw-pim (pdf-info-metadata doc))
+        (temp-buff-name (if combined
+                            "*PDF metadata and font info*"
+                            "*PDF metadata*")))
+    (get-buffer-create temp-buff-name)
+    (with-current-buffer temp-buff-name
+      (read-only-mode -1)
+      (erase-buffer)
+      (insert (format "* PDF metadata for file \"=%s=\":\n"
+                      (file-name-nondirectory doc)))
+      (dolist (item raw-pim)
+        (let ((fname (car item))
+              (fval (cdr item)))
+          ;; keyword field needs special handling
+          (if (and (listp fval)
+                   (> (length fval) 1)
+                   (equal fname 'keywords))
+              (let ((kword1 (cadr fval))
+                    (kwords (cddr fval)))
+                (insert (format "- =%s=: " fname))
+                (insert (format "~%s~"
+                                (string-trim kword1)))
+                (dolist (kword kwords)
+                  (insert
+                   (format ", ~%s~"
+                           (string-trim kword))))
+                (insert "\n"))
+            (insert (format "- =%s=: " fname))
+            ;; don't format empty strings or values
+            (if (or (null fval) (string-empty-p fval))
+                (insert "\n")
+              (insert (format "~%s~\n"
+                              (string-trim fval)))))))
+      (org-mode)
+      (org-fold-show-all)
+      (read-only-mode 1)
+      (when (null combined)
+        (switch-to-buffer-other-window temp-buff-name))
+      (goto-char (point-min)))))
+
+;;;; PDF Font information
+(defvar pdf-misc-pdffonts-man-help
+  "** Key to the above font information:
+*** The following information is listed for each font:
+  - =name=: the font name, exactly as given in the PDF file (potentially including
+    a subset prefix)
+  - =type=: the font type -- see below for details
+  - =emb=: \"yes\" if the font is embedded in the PDF file
+  - =sub=: \"yes\" if the font is a subset
+  - =uni=: \"yes\" if there is an explicit ~ToUnicode~ map in the PDF file (the
+    absence of a ~ToUnicode~ map doesn't necessarily mean that the text can't be
+    converted to Unicode)
+  - =object ID=: the font dictionary object ID (number and generation; given here
+    in format ~Number.Generation~)
+
+*** PDF files can contain the following types of fonts:
+   - ~Type 1~
+   - ~Type 1C~ [= Compact Font Format (CFF)]
+   - ~Type 3~
+   - ~TrueType~
+   - ~CID Type 0~ [= 16-bit font with no specified type]
+   - ~CID Type 0C~ [= 16-bit PostScript CFF font]
+   - ~CID TrueType~ [= 16-bit TrueType font]
+
+[ adapted from ~man pdffonts~ ]"
+  "Key to font data information.
+Information about the PDF font information displayed by
+`pdf-misc-display-font-information'.")
+
+(defun pdf-misc--extract-pdffonts-info (doc)
+  "Non-interactive function to parse the output of `pdffonts'.
+Extracts information from calling `pdffonts' utility on PDF document
+`DOC'.  Called by `pdf-misc-display-font-information'."
+  (unless (executable-find "pdffonts")
+    (error "System package `pdffonts' must be installed"))
+  (let* ((raw
+          (remove ""
+                 (split-string
+                  (shell-command-to-string
+                   (concat "pdffonts " doc))
+                  "\n")))
+         (body (cddr raw))
+         (pdffont-values nil))
+    (dolist (line body)
+      (let ((raw-font-info (nreverse
+                            (split-string line))))
+        (let* ((object-id (concat
+                           (nth 1 raw-font-info)
+                           "."
+                           (nth 0 raw-font-info)))
+               (uni (nth 2 raw-font-info))
+               (sub (nth 3 raw-font-info))
+               (emb (nth 4 raw-font-info))
+               (encoding (nth 5 raw-font-info))
+               (remainder (cdddr (cdddr raw-font-info)))
+               (flipback (nreverse remainder))
+               (font-name (car flipback))
+               (type
+                (pdf-misc--merge-cons-to-string
+                 (pdf-misc--flatten-tree
+                       (cdr flipback)))))
+          (setq pdffont-values
+                (cons
+                 (list
+                  font-name
+                  type
+                  encoding
+                  emb
+                  sub
+                  uni
+                  object-id)
+                 pdffont-values)))))
+    pdffont-values))
+
+(defun pdf-misc-display-font-information (doc &optional combined)
+  "Parse the output of `pdffonts' for PDF file `DOC'.
+Information is display in an Org-mode table in a temporary buffer.
+Includes explanatory information if called with prefix argument.
+\(I.e., if command is preceded by `C-u'.\) Optional `COMBINED' argument
+alters behaviour for use with
+`pdf-misc-display-combined-metadata-and-font-info'."
+  (interactive
+   (if (pdf-tools-pdf-buffer-p)
+       (list (buffer-file-name))
+     (list (read-file-name "Choose PDF file:"))))
+  (unless (executable-find "pdffonts")
+    (error "System package `pdffonts' must be installed"))
+  (let ((pdffont-values (pdf-misc--extract-pdffonts-info doc))
+        (temp-buff-name (if combined
+                            "*PDF metadata and font info*"
+                          "*PDF fonts*")))
+    (when (null combined)
+      (get-buffer-create temp-buff-name))
+    (with-current-buffer temp-buff-name
+      (read-only-mode -1)
+      (if combined
+          (progn
+            (goto-char (point-max))
+            (insert "\n"))
+        (erase-buffer))
+      (insert (format "* PDF font information for file \"=%s=\":\n"
+                      (file-name-nondirectory doc)))
+      (insert "|-\n")
+      (let ((header '("=name=" "=type=" "=encoding=" "=emb=" "=sub=" "=uni=" "=object ID=")))
+          (dolist (field header)
+            (insert " | ")
+            (insert field)))
+      (insert "|\n")
+      (insert "|--")
+      (insert "\n")
+      (goto-char (point-max))
+      (dolist (item pdffont-values)
+        (let ((ffield t))
+          (dolist (field item)
+            (insert " | ")
+            (if ffield
+                (progn
+                  (insert (format "~%s~" field))
+                  (setq ffield nil))
+              (insert (format "%s" field)))))
+        (insert "\n"))
+      (insert "|-")
+      (org-mode)
+      (org-fold-show-all)
+      (org-table-align)
+      (org-table-align) ; needs to be twice to get formatting right
+      (goto-char (point-max))
+      (when current-prefix-arg
+        (insert "\n")
+        (insert pdf-misc-pdffonts-man-help))
+      (read-only-mode 1)
+      (switch-to-buffer-other-window temp-buff-name)
+      ;; visual-fill-column-mode will be too narrow
+      ;; disable if on:
+      (when (and (boundp 'visual-fill-column-mode)
+             visual-fill-column-mode)
+        (visual-fill-column-mode -1))
+      (goto-char (point-min)))))
+
+;;;; Combined PDF metadata and font information display
+
+(defun pdf-misc-display-combined-metadata-and-font-info (doc)
+  "Show combined PDF metadata and font information.
+Operates on PDF document `DOC', either current buffer, or passed
+manually, or user is queried to supply one.  \(Prefixed argument
+triggers showing explanatory information for font metadata.\)"
+  (interactive
+   (if (pdf-tools-pdf-buffer-p)
+       (list (buffer-file-name))
+     (list (read-file-name "Choose PDF file:"))))
+  (pdf-misc-display-metadata-org-style doc t)
+  (pdf-misc-display-font-information doc t))
+
+
+;;; Misc. things, printing
 (defgroup pdf-misc nil
   "Miscellaneous options for PDF documents."
   :group 'pdf-tools)


### PR DESCRIPTION
- access to `pdffonts` information
- display of font information in an org-mode-ish temp buffer
- alternative pdf metadata in org-mode-ish temp buffer
- combined pdf metadata and font info in temp buffer
- three new bindings for above 3 things
- minor cleanups & re-organisation