### PR TITLE
Add gamma correction option to midnight mode (and fix a few bugs).

### DIFF
--- a/lisp/pdf-info.el
+++ b/lisp/pdf-info.el
@@ -572,6 +572,8 @@ interrupted."
            (cl-case key
              ((:render/printed)
               (setq value (equal value "1")))
+             ((:render/gammabeforeinvert)
+              (setq value (equal value "1")))
              ((:render/usecolors)
               (setq value (ignore-errors
                             (let ((int-val (cl-parse-integer value)))
@@ -1733,6 +1735,8 @@ Returns a list \(LEFT TOP RIGHT BOT\)."
              (push (pdf-util-hexcolor value)
                    soptions))
             ((:render/printed)
+             (push (if value 1 0) soptions))
+            ((:render/gammabeforeinvert)
              (push (if value 1 0) soptions))
             ((:render/usecolors)
              ;; 0 -> original color

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -132,6 +132,29 @@ Nevertheless, this seems to work well in most cases."
   :group 'pdf-view
   :type 'boolean)
 
+(defcustom pdf-view-midnight-gamma 1.0
+  "In midnight mode, nonlinearly scale lightness.
+
+Values less than 1 increase lightness, values more than 1 decrease
+lightness (unless `pdf-view-midnight-gamma-before-invert' is non-nil, in
+which reverses the effect direction)."
+  :group 'pdf-view
+  :type 'float)
+
+(defcustom pdf-view-midnight-gamma-before-invert nil
+  "In midnight mode, whether to scale lightness before inverting.
+
+If non-nil, this inverts the direction of the effect of
+`pdf-view-midnight-gamma', i.e. values more than 1 increase lightness
+instead of decreasing it. This option is provided because it results in
+different behaviors near the ends of the lightness scale. For example,
+if this option is nil (the default), then a gamma values less than 1
+significantly lighten colors very close to black. One gets a less
+extreme effect by setting this option to non-nil and using gamma values
+greater than 1."
+  :group 'pdf-view
+  :type 'boolean)
+
 (defcustom pdf-view-change-page-hook nil
   "Hook run after changing to another page, but before displaying it.
 
@@ -1283,6 +1306,8 @@ The colors are determined by the variable
                   (pdf-info-setoptions
                    :render/foreground (or (car pdf-view-midnight-colors) "black")
                    :render/background (or (cdr pdf-view-midnight-colors) "white")
+                   :render/gamma pdf-view-midnight-gamma
+                   :render/gammabeforeinvert pdf-view-midnight-gamma-before-invert
                    :render/usecolors
                    (if pdf-view-midnight-invert
                        ;; If midnight invert is enabled, pass "2" indicating

--- a/server/epdfinfo.h
+++ b/server/epdfinfo.h
@@ -165,6 +165,7 @@ typedef enum
     ARG_INVALID = 0,
     ARG_DOC,
     ARG_BOOL,
+    ARG_DOUBLE,
     ARG_STRING,
     ARG_NONEMPTY_STRING,
     ARG_NATNUM,
@@ -188,6 +189,8 @@ typedef struct
   PopplerColor bg, fg;
   gboolean usecolors;
   gboolean printed;
+  gboolean gammabeforeinvert;
+  gdouble gamma;
 } render_options_t;
 
 typedef struct
@@ -214,6 +217,7 @@ typedef struct
   union
   {
     gboolean flag;
+    gdouble scalar;
     const char *string;
     long natnum;
     document_t *doc;


### PR DESCRIPTION
I use pdf-tools's midnight mode for viewing PDFs produced by LaTeX, but I found that colorful text would often have much lower contrast with the background in midnight mode than the original. As a quick hack to fix this, I added an option that allows gamma correcting the PDF in midnight mode. There are two natural ways to do this (before or after inversion), so there's an option to select the preferred way. Along the way, I found and fixed a few bugs in midnight mode.

---

Gamma correction means rasing the lightness (scaled to range from 0 to 1) of all colors in an image to some exponent; the chosen exponent is called "gamma". Choosing gamma more than 1 darkens the image, and choosing gamma less than 1 lightens it. The default is 1, which has no effect.

There's another option that determines whether we apply gamma correction before or after inverting lightness. The default is to apply gamma correction after inversion.

I found that I preferred the way things looked when applying the gamma correction before inversion, which is why the option is here. One caveat is that doing the correction before inversion reverses the effect direction, i.e., choosing gamma more than 1 lightens the image, and choosing gamma less than 1 darkens it.

This commit also fixes a midnight mode bug that was present when converting from integer RGB to double RGB: we were dividing by 256 instead of 255. This had a few bad effects. First, it meant that the background was slightly the wrong color. This was often not visible due to rounding, but it became visible when using gamma correction. Second, it meant that the fast path mapping white to the background color never fired.

Finally, just as there's a fast path mapping white to the background color, there was a comment mentioning a fast path mapping black to the foreground color, but it wasn't in the code. So this commit adds that fast path, too.