### PR TITLE
Add option to display page labels in mode line

### DIFF
--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -212,6 +212,16 @@ Must be one of `glyph', `word', or `line'."
                  (const word)
                  (const line)))
 
+(defcustom pdf-view-mode-line-position-prefix "P"
+  "Prefix for page number shown in the mode line."
+  :group 'pdf-view
+  :type 'string)
+
+(defcustom pdf-view-mode-line-position-use-labels nil
+  "Whether current page should come from page labels."
+  :group 'pdf-view
+  :type 'boolean)
+
 
 ;; * ================================================================== *
 ;; * Internal variables and macros
@@ -388,7 +398,13 @@ PNG images in Emacs buffers."
 
   ;; Setup other local variables.
   (setq-local mode-line-position
-              '(" P" (:eval (number-to-string (pdf-view-current-page)))
+              '(" " pdf-view-mode-line-position-prefix
+                ;; Show page label when enabled and available,
+                ;; otherwise show numeric page. Guard against errors.
+                (:eval
+                 (or (and pdf-view-mode-line-position-use-labels
+                          (ignore-errors (pdf-view-current-pagelabel)))
+                     (number-to-string (pdf-view-current-page))))
                 ;; Avoid errors during redisplay.
                 "/" (:eval (or (ignore-errors
                                  (number-to-string (pdf-cache-number-of-pages)))


### PR DESCRIPTION
Summary
-------
Show page labels in mode-line when enabled. Provide a customizable prefix and
a safe fallback to the numeric page count when labels are absent or an error
occurs during redisplay.

What changed
------------
- Add two defcustoms:
  * `pdf-view-mode-line-position-prefix` (string) to control the prefix shown.
  * `pdf-view-mode-line-position-use-labels` (boolean) to toggle label use.
- Replace mode-line-position content to:
  * Prefer page label when enabled and available.
  * Fall back to numeric page.
  * Use `ignore-errors` so redisplay does not throw on transient errors.
  * Keep total pages display as before with a "???" fallback.

Why
---
Users expect PDFs that use page labels (Roman numerals, section numbering,
etc.) to show those labels in the mode line. The previous mode-line only
displayed numeric pages. This change is opt-in and safe.

Testing
-------
1. Load a PDF with custom page labels (or create one).
2. In Emacs, enable labels:
   M-: (setq pdf-view-mode-line-position-use-labels t) RET
3. Open the PDF in pdf-view. The mode-line should show the label for the
   current page. If labels are not present it should show the numeric page.
4. Toggle the prefix via M-x customize-group RET pdf-view RET and change
   `Mode Line Position Prefix`.

Notes
-----
- This is intentionally opt-in to avoid changing behavior for users who
  prefer numeric indexes.
- I added `:type` and `:group` so these options appear correctly in
  customize.

If you want I can:
- adjust wording or naming (`pdf-view-mode-line-prefix` etc.)
- add a small entry to the package NEWS or the top-level README.
